### PR TITLE
Ddl pess dev

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -214,7 +214,7 @@ endif
 
 server:
 ifeq ($(TARGET), "")
-	CGO_ENABLED=1 $(GOBUILD) $(RACE_FLAG) -ldflags '$(LDFLAGS) $(CHECK_FLAG)' -o bin/tidb-server tidb-server/main.go
+	CGO_ENABLED=1 $(GOBUILD) $(RACE_FLAG) -ldflags '$(LDFLAGS) $(CHECK_FLAG)' -gcflags="all=-N -l" -o bin/tidb-server tidb-server/main.go
 else
 	CGO_ENABLED=1 $(GOBUILD) $(RACE_FLAG) -ldflags '$(LDFLAGS) $(CHECK_FLAG)' -o '$(TARGET)' tidb-server/main.go
 endif

--- a/ddl/index.go
+++ b/ddl/index.go
@@ -1041,7 +1041,7 @@ func (w *addIndexWorker) batchCheckUniqueKey(txn kv.Transaction, idxRecords []*i
 	for i, key := range w.batchCheckKeys {
 		if val, found := batchVals[string(key)]; found {
 			if w.distinctCheckFlags[i] {
-				handle, err1 := tables.DecodeHandleInUniqueIndexValue(val, w.table.Meta().IsCommonHandle)
+				handle, err1 := tablecodec.DecodeHandleInUniqueIndexValue(val, w.table.Meta().IsCommonHandle)
 				if err1 != nil {
 					return errors.Trace(err1)
 				}
@@ -1055,7 +1055,7 @@ func (w *addIndexWorker) batchCheckUniqueKey(txn kv.Transaction, idxRecords []*i
 			// The keys in w.batchCheckKeys also maybe duplicate,
 			// so we need to backfill the not found key into `batchVals` map.
 			if w.distinctCheckFlags[i] {
-				batchVals[string(key)] = tables.EncodeHandleInUniqueIndexValue(idxRecords[i].handle, false)
+				batchVals[string(key)] = tablecodec.EncodeHandleInUniqueIndexValue(idxRecords[i].handle, false)
 			}
 		}
 	}

--- a/domain/domain.go
+++ b/domain/domain.go
@@ -81,14 +81,14 @@ type Domain struct {
 // loadInfoSchema loads infoschema at startTS into handle, usedSchemaVersion is the currently used
 // infoschema version, if it is the same as the schema version at startTS, we don't need to reload again.
 // It returns the latest schema version, the changed table IDs, whether it's a full load and an error.
-func (do *Domain) loadInfoSchema(handle *infoschema.Handle, usedSchemaVersion int64, startTS uint64) (int64, []int64, []uint64, bool, error) {
-	var fullLoad bool
+func (do *Domain) loadInfoSchema(handle *infoschema.Handle, usedSchemaVersion int64,
+	startTS uint64) (neededSchemaVersion int64, tblIDs []int64, actionTypes []uint64, fullLoad bool, err error) {
 	snapshot, err := do.store.GetSnapshot(kv.NewVersion(startTS))
 	if err != nil {
 		return 0, nil, nil, fullLoad, err
 	}
 	m := meta.NewSnapshotMeta(snapshot)
-	neededSchemaVersion, err := m.GetSchemaVersion()
+	neededSchemaVersion, err = m.GetSchemaVersion()
 	if err != nil {
 		return 0, nil, nil, fullLoad, err
 	}

--- a/domain/domain.go
+++ b/domain/domain.go
@@ -81,19 +81,19 @@ type Domain struct {
 // loadInfoSchema loads infoschema at startTS into handle, usedSchemaVersion is the currently used
 // infoschema version, if it is the same as the schema version at startTS, we don't need to reload again.
 // It returns the latest schema version, the changed table IDs, whether it's a full load and an error.
-func (do *Domain) loadInfoSchema(handle *infoschema.Handle, usedSchemaVersion int64, startTS uint64) (int64, []int64, bool, error) {
+func (do *Domain) loadInfoSchema(handle *infoschema.Handle, usedSchemaVersion int64, startTS uint64) (int64, []int64, []uint64, bool, error) {
 	var fullLoad bool
 	snapshot, err := do.store.GetSnapshot(kv.NewVersion(startTS))
 	if err != nil {
-		return 0, nil, fullLoad, err
+		return 0, nil, nil, fullLoad, err
 	}
 	m := meta.NewSnapshotMeta(snapshot)
 	neededSchemaVersion, err := m.GetSchemaVersion()
 	if err != nil {
-		return 0, nil, fullLoad, err
+		return 0, nil, nil, fullLoad, err
 	}
 	if usedSchemaVersion != 0 && usedSchemaVersion == neededSchemaVersion {
-		return neededSchemaVersion, nil, fullLoad, nil
+		return neededSchemaVersion, nil, nil, fullLoad, nil
 	}
 
 	// Update self schema version to etcd.
@@ -117,7 +117,7 @@ func (do *Domain) loadInfoSchema(handle *infoschema.Handle, usedSchemaVersion in
 	}()
 
 	startTime := time.Now()
-	ok, tblIDs, err := do.tryLoadSchemaDiffs(m, usedSchemaVersion, neededSchemaVersion)
+	ok, tblIDs, actions, err := do.tryLoadSchemaDiffs(m, usedSchemaVersion, neededSchemaVersion)
 	if err != nil {
 		// We can fall back to full load, don't need to return the error.
 		logutil.BgLogger().Error("failed to load schema diff", zap.Error(err))
@@ -128,25 +128,25 @@ func (do *Domain) loadInfoSchema(handle *infoschema.Handle, usedSchemaVersion in
 			zap.Int64("neededSchemaVersion", neededSchemaVersion),
 			zap.Duration("start time", time.Since(startTime)),
 			zap.Int64s("tblIDs", tblIDs))
-		return neededSchemaVersion, tblIDs, fullLoad, nil
+		return neededSchemaVersion, tblIDs, actions, fullLoad, nil
 	}
 
 	fullLoad = true
 	schemas, err := do.fetchAllSchemasWithTables(m)
 	if err != nil {
-		return 0, nil, fullLoad, err
+		return 0, nil, nil, fullLoad, err
 	}
 
 	newISBuilder, err := infoschema.NewBuilder(handle).InitWithDBInfos(schemas, neededSchemaVersion)
 	if err != nil {
-		return 0, nil, fullLoad, err
+		return 0, nil, nil, fullLoad, err
 	}
 	logutil.BgLogger().Info("full load InfoSchema success",
 		zap.Int64("usedSchemaVersion", usedSchemaVersion),
 		zap.Int64("neededSchemaVersion", neededSchemaVersion),
 		zap.Duration("start time", time.Since(startTime)))
 	newISBuilder.Build()
-	return neededSchemaVersion, nil, fullLoad, nil
+	return neededSchemaVersion, nil, nil, fullLoad, nil
 }
 
 func (do *Domain) fetchAllSchemasWithTables(m *meta.Meta) ([]*model.DBInfo, error) {
@@ -234,39 +234,43 @@ func isTooOldSchema(usedVersion, newVersion int64) bool {
 // Return true if the schema is loaded successfully.
 // Return false if the schema can not be loaded by schema diff, then we need to do full load.
 // The second returned value is the delta updated table and partition IDs.
-func (do *Domain) tryLoadSchemaDiffs(m *meta.Meta, usedVersion, newVersion int64) (bool, []int64, error) {
+func (do *Domain) tryLoadSchemaDiffs(m *meta.Meta, usedVersion, newVersion int64) (bool, []int64, []uint64, error) {
 	// If there isn't any used version, or used version is too old, we do full load.
 	// And when users use history read feature, we will set usedVersion to initialVersion, then full load is needed.
 	if isTooOldSchema(usedVersion, newVersion) {
-		return false, nil, nil
+		return false, nil, nil, nil
 	}
 	var diffs []*model.SchemaDiff
 	for usedVersion < newVersion {
 		usedVersion++
 		diff, err := m.GetSchemaDiff(usedVersion)
 		if err != nil {
-			return false, nil, err
+			return false, nil, nil, err
 		}
 		if diff == nil {
 			// If diff is missing for any version between used and new version, we fall back to full reload.
-			return false, nil, nil
+			return false, nil, nil, nil
 		}
 		diffs = append(diffs, diff)
 	}
 	builder := infoschema.NewBuilder(do.infoHandle).InitWithOldInfoSchema()
 	tblIDs := make([]int64, 0, len(diffs))
+	actions := make([]uint64, 0, len(diffs))
 	for _, diff := range diffs {
 		ids, err := builder.ApplyDiff(m, diff)
 		if err != nil {
-			return false, nil, err
+			return false, nil, nil, err
 		}
 		if canSkipSchemaCheckerDDL(diff.Type) {
 			continue
 		}
 		tblIDs = append(tblIDs, ids...)
+		for i := 0; i < len(ids); i++ {
+			actions = append(actions, uint64(1<<diff.Type))
+		}
 	}
 	builder.Build()
-	return true, tblIDs, nil
+	return true, tblIDs, actions, nil
 }
 
 func canSkipSchemaCheckerDDL(tp model.ActionType) bool {
@@ -286,7 +290,7 @@ func (do *Domain) InfoSchema() infoschema.InfoSchema {
 func (do *Domain) GetSnapshotInfoSchema(snapshotTS uint64) (infoschema.InfoSchema, error) {
 	snapHandle := do.infoHandle.EmptyClone()
 	// For the snapHandle, it's an empty Handle, so its usedSchemaVersion is initialVersion.
-	_, _, _, err := do.loadInfoSchema(snapHandle, initialVersion, snapshotTS)
+	_, _, _, _, err := do.loadInfoSchema(snapHandle, initialVersion, snapshotTS)
 	if err != nil {
 		return nil, err
 	}
@@ -355,8 +359,9 @@ func (do *Domain) Reload() error {
 	var (
 		fullLoad                bool
 		changedPhysicalTableIDs []int64
+		changedActionTypes      []uint64
 	)
-	neededSchemaVersion, changedPhysicalTableIDs, fullLoad, err = do.loadInfoSchema(do.infoHandle, schemaVersion, ver.Ver)
+	neededSchemaVersion, changedPhysicalTableIDs, changedActionTypes, fullLoad, err = do.loadInfoSchema(do.infoHandle, schemaVersion, ver.Ver)
 	metrics.LoadSchemaDuration.Observe(time.Since(startTime).Seconds())
 	if err != nil {
 		metrics.LoadSchemaCounter.WithLabelValues("failed").Inc()
@@ -368,7 +373,7 @@ func (do *Domain) Reload() error {
 		logutil.BgLogger().Info("full load and reset schema validator")
 		do.SchemaValidator.Reset()
 	}
-	do.SchemaValidator.Update(ver.Ver, schemaVersion, neededSchemaVersion, changedPhysicalTableIDs)
+	do.SchemaValidator.Update(ver.Ver, schemaVersion, neededSchemaVersion, changedPhysicalTableIDs, changedActionTypes)
 
 	lease := do.DDL().GetLease()
 	sub := time.Since(startTime)

--- a/domain/domain_test.go
+++ b/domain/domain_test.go
@@ -314,24 +314,24 @@ func (*testSuite) TestT(c *C) {
 	c.Assert(err, IsNil)
 	ts := ver.Ver
 
-	succ := dom.SchemaValidator.Check(ts, schemaVer, nil)
+	_, _, succ := dom.SchemaValidator.Check(ts, schemaVer, nil, false)
 	c.Assert(succ, Equals, ResultSucc)
 	c.Assert(failpoint.Enable("github.com/pingcap/tidb/domain/ErrorMockReloadFailed", `return(true)`), IsNil)
 	err = dom.Reload()
 	c.Assert(err, NotNil)
-	succ = dom.SchemaValidator.Check(ts, schemaVer, nil)
+	_, _, succ = dom.SchemaValidator.Check(ts, schemaVer, nil, false)
 	c.Assert(succ, Equals, ResultSucc)
 	time.Sleep(ddlLease)
 
 	ver, err = store.CurrentVersion()
 	c.Assert(err, IsNil)
 	ts = ver.Ver
-	succ = dom.SchemaValidator.Check(ts, schemaVer, nil)
+	_, _, succ = dom.SchemaValidator.Check(ts, schemaVer, nil, false)
 	c.Assert(succ, Equals, ResultUnknown)
 	c.Assert(failpoint.Disable("github.com/pingcap/tidb/domain/ErrorMockReloadFailed"), IsNil)
 	err = dom.Reload()
 	c.Assert(err, IsNil)
-	succ = dom.SchemaValidator.Check(ts, schemaVer, nil)
+	_, _, succ = dom.SchemaValidator.Check(ts, schemaVer, nil, false)
 	c.Assert(succ, Equals, ResultSucc)
 
 	// For slow query.
@@ -396,7 +396,7 @@ func (*testSuite) TestT(c *C) {
 		SchemaOutOfDateRetryInterval = originalRetryInterval
 	}()
 	dom.SchemaValidator.Stop()
-	err = schemaChecker.Check(uint64(123456))
+	_, _, _, err = schemaChecker.Check(uint64(123456), false)
 	c.Assert(err.Error(), Equals, ErrInfoSchemaExpired.Error())
 	dom.SchemaValidator.Reset()
 

--- a/domain/schema_checker.go
+++ b/domain/schema_checker.go
@@ -44,22 +44,23 @@ func NewSchemaChecker(do *Domain, schemaVer int64, relatedTableIDs []int64) *Sch
 }
 
 // Check checks the validity of the schema version.
-func (s *SchemaChecker) Check(txnTS uint64) error {
+func (s *SchemaChecker) Check(txnTS uint64, getAllChangedInfo bool) ([]int64, []uint64, bool, error) {
 	schemaOutOfDateRetryInterval := atomic.LoadInt64(&SchemaOutOfDateRetryInterval)
 	schemaOutOfDateRetryTimes := int(atomic.LoadInt32(&SchemaOutOfDateRetryTimes))
 	for i := 0; i < schemaOutOfDateRetryTimes; i++ {
-		result := s.SchemaValidator.Check(txnTS, s.schemaVer, s.relatedTableIDs)
-		switch result {
+		tblIDs, typeActions, CheckResult := s.SchemaValidator.Check(txnTS, s.schemaVer, s.relatedTableIDs, getAllChangedInfo)
+		switch CheckResult {
 		case ResultSucc:
-			return nil
+			return nil, nil, false, nil
 		case ResultFail:
 			metrics.SchemaLeaseErrorCounter.WithLabelValues("changed").Inc()
-			return ErrInfoSchemaChanged
+			amendable := getAllChangedInfo && (len(tblIDs) > 0)
+			return tblIDs, typeActions, amendable, ErrInfoSchemaChanged
 		case ResultUnknown:
 			time.Sleep(time.Duration(schemaOutOfDateRetryInterval))
 		}
 
 	}
 	metrics.SchemaLeaseErrorCounter.WithLabelValues("outdated").Inc()
-	return ErrInfoSchemaExpired
+	return nil, nil, false, ErrInfoSchemaExpired
 }

--- a/domain/schema_checker_test.go
+++ b/domain/schema_checker_test.go
@@ -27,38 +27,38 @@ func (s *testSuite) TestSchemaCheckerSimple(c *C) {
 
 	// Add some schema versions and delta table IDs.
 	ts := uint64(time.Now().UnixNano())
-	validator.Update(ts, 0, 2, []int64{1})
-	validator.Update(ts, 2, 4, []int64{2})
+	validator.Update(ts, 0, 2, []int64{1}, []uint64{1})
+	validator.Update(ts, 2, 4, []int64{2}, []uint64{2})
 
 	// checker's schema version is the same as the current schema version.
 	checker.schemaVer = 4
-	err := checker.Check(ts)
+	_, _, _, err := checker.Check(ts, false)
 	c.Assert(err, IsNil)
 
 	// checker's schema version is less than the current schema version, and it doesn't exist in validator's items.
 	// checker's related table ID isn't in validator's changed table IDs.
 	checker.schemaVer = 2
 	checker.relatedTableIDs = []int64{3}
-	err = checker.Check(ts)
+	_, _, _, err = checker.Check(ts, false)
 	c.Assert(err, IsNil)
 	// The checker's schema version isn't in validator's items.
 	checker.schemaVer = 1
 	checker.relatedTableIDs = []int64{3}
-	err = checker.Check(ts)
+	_, _, _, err = checker.Check(ts, false)
 	c.Assert(terror.ErrorEqual(err, ErrInfoSchemaChanged), IsTrue)
 	// checker's related table ID is in validator's changed table IDs.
 	checker.relatedTableIDs = []int64{2}
-	err = checker.Check(ts)
+	_, _, _, err = checker.Check(ts, false)
 	c.Assert(terror.ErrorEqual(err, ErrInfoSchemaChanged), IsTrue)
 
 	// validator's latest schema version is expired.
 	time.Sleep(lease + time.Microsecond)
 	checker.schemaVer = 4
 	checker.relatedTableIDs = []int64{3}
-	err = checker.Check(ts)
+	_, _, _, err = checker.Check(ts, false)
 	c.Assert(err, IsNil)
 	nowTS := uint64(time.Now().UnixNano())
 	// Use checker.SchemaValidator.Check instead of checker.Check here because backoff make CI slow.
-	result := checker.SchemaValidator.Check(nowTS, checker.schemaVer, checker.relatedTableIDs)
+	_, _, result := checker.SchemaValidator.Check(nowTS, checker.schemaVer, checker.relatedTableIDs, false)
 	c.Assert(result, Equals, ResultUnknown)
 }

--- a/domain/schema_validator.go
+++ b/domain/schema_validator.go
@@ -14,6 +14,7 @@
 package domain
 
 import (
+	log "github.com/sirupsen/logrus"
 	"sort"
 	"sync"
 	"time"
@@ -42,9 +43,9 @@ type SchemaValidator interface {
 	// The latest schemaVer is valid within leaseGrantTime plus lease duration.
 	// Add the changed table IDs to the new schema information,
 	// which is produced when the oldSchemaVer is updated to the newSchemaVer.
-	Update(leaseGrantTime uint64, oldSchemaVer, newSchemaVer int64, changedTableIDs []int64, changedActionTypes []uint64)
+	Update(leaseGrantTime uint64, oldSchemaVer, newSchemaVer int64, change *relatedSchemaChange)
 	// Check is it valid for a transaction to use schemaVer and related tables, at timestamp txnTS.
-	Check(txnTS uint64, schemaVer int64, relatedPhysicalTableIDs []int64, getAllInfo bool) ([]int64, []uint64, checkResult)
+	Check(txnTS uint64, schemaVer int64, relatedPhysicalTableIDs []int64, getAllInfo bool) ([]int64, []int64, []uint64, checkResult)
 	// Stop stops checking the valid of transaction.
 	Stop()
 	// Restart restarts the schema validator after it is stopped.
@@ -56,9 +57,10 @@ type SchemaValidator interface {
 }
 
 type deltaSchemaInfo struct {
-	schemaVersion  int64
-	relatedIDs     []int64
-	relatedActions []uint64
+	schemaVersion    int64
+	relatedSchemaIDS []int64
+	relatedIDs       []int64
+	relatedActions   []uint64
 }
 
 type schemaValidator struct {
@@ -121,7 +123,7 @@ func (s *schemaValidator) Reset() {
 	s.deltaSchemaInfos = s.deltaSchemaInfos[:0]
 }
 
-func (s *schemaValidator) Update(leaseGrantTS uint64, oldVer, currVer int64, changedTableIDs []int64, changedActionTypes []uint64) {
+func (s *schemaValidator) Update(leaseGrantTS uint64, oldVer, currVer int64, change *relatedSchemaChange) {
 	s.mux.Lock()
 	defer s.mux.Unlock()
 
@@ -139,41 +141,49 @@ func (s *schemaValidator) Update(leaseGrantTS uint64, oldVer, currVer int64, cha
 	// Update the schema deltaItem information.
 	if currVer != oldVer {
 		logutil.BgLogger().Debug("update schema validator", zap.Int64("oldVer", oldVer),
-			zap.Int64("currVer", currVer), zap.Int64s("changedTableIDs", changedTableIDs),
-			zap.Uint64s("changedActionTypes", changedActionTypes))
-		s.enqueue(currVer, changedTableIDs, changedActionTypes)
+			zap.Int64("currVer", currVer))
+		if change != nil {
+			//zap.Int64s("changedTableIDs", change.tblIDS),
+			//zap.Uint64s("changedActionTypes", change.actionTypes))
+			log.Infof("[for debug] change=%v", *change)
+			s.enqueue(currVer, change)
+		}
 	}
 }
 
 // isRelatedTablesChanged returns the result whether relatedTableIDs is changed
 // from usedVer to the latest schema version.
 // NOTE, this function should be called under lock!
-func (s *schemaValidator) isRelatedTablesChanged(currVer int64, tableIDs []int64, getAllInfo bool) ([]int64, []uint64, bool) {
+func (s *schemaValidator) isRelatedTablesChanged(currVer int64, tableIDs []int64, getAllInfo bool) (*relatedSchemaChange, bool) {
 	if len(s.deltaSchemaInfos) == 0 {
 		metrics.LoadSchemaCounter.WithLabelValues(metrics.SchemaValidatorCacheEmpty).Inc()
 		logutil.BgLogger().Info("schema change history is empty", zap.Int64("currVer", currVer))
-		return nil, nil, true
+		return nil, true
 	}
 	newerDeltas := s.findNewerDeltas(currVer)
-	if len(newerDeltas) == len(s.deltaSchemaInfos) {
-		metrics.LoadSchemaCounter.WithLabelValues(metrics.SchemaValidatorCacheMiss).Inc()
-		logutil.BgLogger().Info("the schema version is much older than the latest version", zap.Int64("currVer", currVer),
-			zap.Int64("latestSchemaVer", s.latestSchemaVer), zap.Reflect("deltas", newerDeltas))
-		return nil, nil, true
-	}
+	/*
+		if len(newerDeltas) == len(s.deltaSchemaInfos) {
+			metrics.LoadSchemaCounter.WithLabelValues(metrics.SchemaValidatorCacheMiss).Inc()
+			logutil.BgLogger().Info("the schema version is much older than the latest version", zap.Int64("currVer", currVer),
+				zap.Int64("latestSchemaVer", s.latestSchemaVer), zap.Reflect("deltas", newerDeltas))
+			return nil, true
+		}
+	*/
 
 	changedTblMap := make(map[int64]uint64)
+	dbIDs := make([]int64, 0, 4)
 	for _, item := range newerDeltas {
 		for i, tblID := range item.relatedIDs {
 			for _, relatedTblID := range tableIDs {
 				if tblID == relatedTblID {
 					if !getAllInfo {
-						return nil, nil, true
+						return nil, true
 					}
 					if _, ok := changedTblMap[tblID]; !ok {
 						changedTblMap[tblID] = 0
 					}
 					changedTblMap[tblID] |= item.relatedActions[i]
+					dbIDs = append(dbIDs, item.relatedSchemaIDS...)
 				}
 			}
 		}
@@ -188,9 +198,14 @@ func (s *schemaValidator) isRelatedTablesChanged(currVer int64, tableIDs []int64
 		for _, tblID := range tblIds {
 			actionTypes = append(actionTypes, changedTblMap[tblID])
 		}
-		return tblIds, actionTypes, true
+		res := &relatedSchemaChange{
+			dbIDs:       dbIDs,
+			tblIDS:      tblIds,
+			actionTypes: actionTypes,
+		}
+		return res, true
 	}
-	return nil, nil, false
+	return nil, false
 }
 
 func (s *schemaValidator) findNewerDeltas(currVer int64) []deltaSchemaInfo {
@@ -204,15 +219,15 @@ func (s *schemaValidator) findNewerDeltas(currVer int64) []deltaSchemaInfo {
 
 // Check checks schema validity, returns true if use schemaVer and related tables at txnTS is legal.
 func (s *schemaValidator) Check(txnTS uint64, schemaVer int64, relatedPhysicalTableIDs []int64,
-	getAllInfo bool) ([]int64, []uint64, checkResult) {
+	getAllInfo bool) ([]int64, []int64, []uint64, checkResult) {
 	s.mux.RLock()
 	defer s.mux.RUnlock()
 	if !s.isStarted {
 		logutil.BgLogger().Info("the schema validator stopped before checking")
-		return nil, nil, ResultUnknown
+		return nil, nil, nil, ResultUnknown
 	}
 	if s.lease == 0 {
-		return nil, nil, ResultSucc
+		return nil, nil, nil, ResultSucc
 	}
 
 	// Schema changed, result decided by whether related tables change.
@@ -221,32 +236,35 @@ func (s *schemaValidator) Check(txnTS uint64, schemaVer int64, relatedPhysicalTa
 		if len(relatedPhysicalTableIDs) == 0 {
 			logutil.BgLogger().Info("the related physical table ID is empty", zap.Int64("schemaVer", schemaVer),
 				zap.Int64("latestSchemaVer", s.latestSchemaVer))
-			return nil, nil, ResultFail
+			return nil, nil, nil, ResultFail
 		}
 
-		tblIds, actionTypes, changed := s.isRelatedTablesChanged(schemaVer, relatedPhysicalTableIDs, getAllInfo)
+		relatedChanges, changed := s.isRelatedTablesChanged(schemaVer, relatedPhysicalTableIDs, getAllInfo)
 		if changed {
-			return tblIds, actionTypes, ResultFail
+			if relatedChanges != nil {
+				return relatedChanges.dbIDs, relatedChanges.tblIDS, relatedChanges.actionTypes, ResultFail
+			}
+			return nil, nil, nil, ResultFail
 		}
-		return nil, nil, ResultSucc
+		return nil, nil, nil, ResultSucc
 	}
 
 	// Schema unchanged, maybe success or the schema validator is unavailable.
 	t := oracle.GetTimeFromTS(txnTS)
 	if t.After(s.latestSchemaExpire) {
-		return nil, nil, ResultUnknown
+		return nil, nil, nil, ResultUnknown
 	}
-	return nil, nil, ResultSucc
+	return nil, nil, nil, ResultSucc
 }
 
-func (s *schemaValidator) enqueue(schemaVersion int64, relatedPhysicalTableIDs []int64, actionTypes []uint64) {
+func (s *schemaValidator) enqueue(schemaVersion int64, change *relatedSchemaChange) {
 	maxCnt := int(variable.GetMaxDeltaSchemaCount())
 	if maxCnt <= 0 {
 		logutil.BgLogger().Info("the schema validator enqueue", zap.Int("delta max count", maxCnt))
 		return
 	}
 
-	delta := deltaSchemaInfo{schemaVersion, relatedPhysicalTableIDs, actionTypes}
+	delta := deltaSchemaInfo{schemaVersion, change.dbIDs, change.tblIDS, change.actionTypes}
 	if len(s.deltaSchemaInfos) == 0 {
 		s.deltaSchemaInfos = append(s.deltaSchemaInfos, delta)
 		return

--- a/domain/schema_validator_test.go
+++ b/domain/schema_validator_test.go
@@ -49,36 +49,36 @@ func (*testSuite) TestSchemaValidator(c *C) {
 		time.Sleep(delay)
 		// Reload can run arbitrarily, at any time.
 		item := <-leaseGrantCh
-		validator.Update(item.leaseGrantTS, item.oldVer, item.schemaVer, nil)
+		validator.Update(item.leaseGrantTS, item.oldVer, item.schemaVer, nil, nil)
 	}
 
 	// Take a lease, check it's valid.
 	item := <-leaseGrantCh
-	validator.Update(item.leaseGrantTS, item.oldVer, item.schemaVer, []int64{10})
-	valid := validator.Check(item.leaseGrantTS, item.schemaVer, []int64{10})
+	validator.Update(item.leaseGrantTS, item.oldVer, item.schemaVer, []int64{10}, []uint64{10})
+	_, _, valid := validator.Check(item.leaseGrantTS, item.schemaVer, []int64{10}, false)
 	c.Assert(valid, Equals, ResultSucc)
 
 	// Stop the validator, validator's items value is nil.
 	validator.Stop()
 	c.Assert(validator.IsStarted(), IsFalse)
-	isTablesChanged := validator.isRelatedTablesChanged(item.schemaVer, []int64{10})
+	_, _, isTablesChanged := validator.isRelatedTablesChanged(item.schemaVer, []int64{10}, false)
 	c.Assert(isTablesChanged, IsTrue)
-	valid = validator.Check(item.leaseGrantTS, item.schemaVer, []int64{10})
+	_, _, valid = validator.Check(item.leaseGrantTS, item.schemaVer, []int64{10}, false)
 	c.Assert(valid, Equals, ResultUnknown)
 	validator.Restart()
 
 	// Increase the current time by 2 leases, check schema is invalid.
 	ts := uint64(time.Now().Add(2 * lease).UnixNano()) // Make sure that ts has timed out a lease.
-	valid = validator.Check(ts, item.schemaVer, []int64{10})
+	_, _, valid = validator.Check(ts, item.schemaVer, []int64{10}, false)
 	c.Assert(valid, Equals, ResultUnknown, Commentf("validator latest schema ver %v, time %v, item schema ver %v, ts %v",
 		validator.latestSchemaVer, validator.latestSchemaExpire, 0, oracle.GetTimeFromTS(ts)))
 	// Make sure newItem's version is greater than item.schema.
 	newItem := getGreaterVersionItem(c, lease, leaseGrantCh, item.schemaVer)
 	currVer := newItem.schemaVer
-	validator.Update(newItem.leaseGrantTS, newItem.oldVer, currVer, nil)
-	valid = validator.Check(ts, item.schemaVer, nil)
+	validator.Update(newItem.leaseGrantTS, newItem.oldVer, currVer, nil, nil)
+	_, _, valid = validator.Check(ts, item.schemaVer, nil, false)
 	c.Assert(valid, Equals, ResultFail, Commentf("currVer %d, newItem %v", currVer, item))
-	valid = validator.Check(ts, item.schemaVer, []int64{0})
+	_, _, valid = validator.Check(ts, item.schemaVer, []int64{0}, false)
 	c.Assert(valid, Equals, ResultFail, Commentf("currVer %d, newItem %v", currVer, item))
 	// Check the latest schema version must changed.
 	c.Assert(item.schemaVer, Less, validator.latestSchemaVer)
@@ -86,20 +86,20 @@ func (*testSuite) TestSchemaValidator(c *C) {
 	// Make sure newItem's version is greater than currVer.
 	newItem = getGreaterVersionItem(c, lease, leaseGrantCh, currVer)
 	// Update current schema version to newItem's version and the delta table IDs is 1, 2, 3.
-	validator.Update(ts, currVer, newItem.schemaVer, []int64{1, 2, 3})
+	validator.Update(ts, currVer, newItem.schemaVer, []int64{1, 2, 3}, []uint64{1, 2, 3})
 	// Make sure the updated table IDs don't be covered with the same schema version.
-	validator.Update(ts, newItem.schemaVer, newItem.schemaVer, nil)
-	isTablesChanged = validator.isRelatedTablesChanged(currVer, nil)
+	validator.Update(ts, newItem.schemaVer, newItem.schemaVer, nil, nil)
+	_, _, isTablesChanged = validator.isRelatedTablesChanged(currVer, nil, false)
 	c.Assert(isTablesChanged, IsFalse)
-	isTablesChanged = validator.isRelatedTablesChanged(currVer, []int64{2})
+	_, _, isTablesChanged = validator.isRelatedTablesChanged(currVer, []int64{2}, false)
 	c.Assert(isTablesChanged, IsTrue, Commentf("currVer %d, newItem %v", currVer, newItem))
 	// The current schema version is older than the oldest schema version.
-	isTablesChanged = validator.isRelatedTablesChanged(-1, nil)
+	_, _, isTablesChanged = validator.isRelatedTablesChanged(-1, nil, false)
 	c.Assert(isTablesChanged, IsTrue, Commentf("currVer %d, newItem %v", currVer, newItem))
 
 	// All schema versions is expired.
 	ts = uint64(time.Now().Add(2 * lease).UnixNano())
-	valid = validator.Check(ts, newItem.schemaVer, nil)
+	_, _, valid = validator.Check(ts, newItem.schemaVer, nil, false)
 	c.Assert(valid, Equals, ResultUnknown)
 
 	close(exit)
@@ -155,51 +155,100 @@ func (*testSuite) TestEnqueue(c *C) {
 	c.Assert(validator.IsStarted(), IsTrue)
 	// maxCnt is 0.
 	variable.SetMaxDeltaSchemaCount(0)
-	validator.enqueue(1, []int64{11})
+	validator.enqueue(1, []int64{11}, []uint64{11})
 	c.Assert(validator.deltaSchemaInfos, HasLen, 0)
 
 	// maxCnt is 10.
 	variable.SetMaxDeltaSchemaCount(10)
 	ds := []deltaSchemaInfo{
-		{0, []int64{1}},
-		{1, []int64{1}},
-		{2, []int64{1}},
-		{3, []int64{2, 2}},
-		{4, []int64{2}},
-		{5, []int64{1, 4}},
-		{6, []int64{1, 4}},
-		{7, []int64{3, 1, 3}},
-		{8, []int64{1, 2, 3}},
-		{9, []int64{1, 2, 3}},
+		{0, []int64{1}, []uint64{1}},
+		{1, []int64{1}, []uint64{1}},
+		{2, []int64{1}, []uint64{1}},
+		{3, []int64{2, 2}, []uint64{2, 2}},
+		{4, []int64{2}, []uint64{2}},
+		{5, []int64{1, 4}, []uint64{1, 4}},
+		{6, []int64{1, 4}, []uint64{1, 4}},
+		{7, []int64{3, 1, 3}, []uint64{3, 1, 3}},
+		{8, []int64{1, 2, 3}, []uint64{1, 2, 3}},
+		{9, []int64{1, 2, 3}, []uint64{1, 2, 3}},
 	}
 	for _, d := range ds {
-		validator.enqueue(d.schemaVersion, d.relatedIDs)
+		validator.enqueue(d.schemaVersion, d.relatedIDs, d.relatedActions)
 	}
-	validator.enqueue(10, []int64{1})
+	validator.enqueue(10, []int64{1}, []uint64{1})
 	ret := []deltaSchemaInfo{
-		{0, []int64{1}},
-		{2, []int64{1}},
-		{3, []int64{2, 2}},
-		{4, []int64{2}},
-		{6, []int64{1, 4}},
-		{9, []int64{1, 2, 3}},
-		{10, []int64{1}},
+		{0, []int64{1}, []uint64{1}},
+		{2, []int64{1}, []uint64{1}},
+		{3, []int64{2, 2}, []uint64{2, 2}},
+		{4, []int64{2}, []uint64{2}},
+		{6, []int64{1, 4}, []uint64{1, 4}},
+		{9, []int64{1, 2, 3}, []uint64{1, 2, 3}},
+		{10, []int64{1}, []uint64{1}},
 	}
 	c.Assert(validator.deltaSchemaInfos, DeepEquals, ret)
 	// The Items' relatedTableIDs have different order.
-	validator.enqueue(11, []int64{1, 2, 3, 4})
-	validator.enqueue(12, []int64{4, 1, 2, 3, 1})
-	validator.enqueue(13, []int64{4, 1, 3, 2, 5})
-	ret[len(ret)-1] = deltaSchemaInfo{13, []int64{4, 1, 3, 2, 5}}
+	validator.enqueue(11, []int64{1, 2, 3, 4}, []uint64{1, 2, 3, 4})
+	validator.enqueue(12, []int64{4, 1, 2, 3, 1}, []uint64{4, 1, 2, 3, 1})
+	validator.enqueue(13, []int64{4, 1, 3, 2, 5}, []uint64{4, 1, 3, 2, 5})
+	ret[len(ret)-1] = deltaSchemaInfo{13, []int64{4, 1, 3, 2, 5}, []uint64{4, 1, 3, 2, 5}}
 	c.Assert(validator.deltaSchemaInfos, DeepEquals, ret)
 	// The length of deltaSchemaInfos is greater then maxCnt.
-	validator.enqueue(14, []int64{1})
-	validator.enqueue(15, []int64{2})
-	validator.enqueue(16, []int64{3})
-	validator.enqueue(17, []int64{4})
-	ret = append(ret, deltaSchemaInfo{14, []int64{1}})
-	ret = append(ret, deltaSchemaInfo{15, []int64{2}})
-	ret = append(ret, deltaSchemaInfo{16, []int64{3}})
-	ret = append(ret, deltaSchemaInfo{17, []int64{4}})
+	validator.enqueue(14, []int64{1}, []uint64{1})
+	validator.enqueue(15, []int64{2}, []uint64{2})
+	validator.enqueue(16, []int64{3}, []uint64{3})
+	validator.enqueue(17, []int64{4}, []uint64{4})
+	ret = append(ret, deltaSchemaInfo{14, []int64{1}, []uint64{1}})
+	ret = append(ret, deltaSchemaInfo{15, []int64{2}, []uint64{2}})
+	ret = append(ret, deltaSchemaInfo{16, []int64{3}, []uint64{3}})
+	ret = append(ret, deltaSchemaInfo{17, []int64{4}, []uint64{4}})
 	c.Assert(validator.deltaSchemaInfos, DeepEquals, ret[1:])
+}
+
+func (*testSuite) TestEnqueueActionType(c *C) {
+	lease := 10 * time.Millisecond
+	originalCnt := variable.GetMaxDeltaSchemaCount()
+	defer variable.SetMaxDeltaSchemaCount(originalCnt)
+
+	validator := NewSchemaValidator(lease).(*schemaValidator)
+	c.Assert(validator.IsStarted(), IsTrue)
+	// maxCnt is 0.
+	variable.SetMaxDeltaSchemaCount(0)
+	validator.enqueue(1, []int64{11}, []uint64{11})
+	c.Assert(validator.deltaSchemaInfos, HasLen, 0)
+
+	// maxCnt is 10.
+	variable.SetMaxDeltaSchemaCount(10)
+	ds := []deltaSchemaInfo{
+		{0, []int64{1}, []uint64{1}},
+		{1, []int64{1}, []uint64{1}},
+		{2, []int64{1}, []uint64{1}},
+		{3, []int64{2, 2}, []uint64{2, 2}},
+		{4, []int64{2}, []uint64{2}},
+		{5, []int64{1, 4}, []uint64{1, 4}},
+		{6, []int64{1, 4}, []uint64{1, 4}},
+		{7, []int64{3, 1, 3}, []uint64{3, 1, 3}},
+		{8, []int64{1, 2, 3}, []uint64{1, 2, 3}},
+		{9, []int64{1, 2, 3}, []uint64{1, 2, 4}},
+	}
+	for _, d := range ds {
+		validator.enqueue(d.schemaVersion, d.relatedIDs, d.relatedActions)
+	}
+	validator.enqueue(10, []int64{1}, []uint64{15})
+	ret := []deltaSchemaInfo{
+		{0, []int64{1}, []uint64{1}},
+		{2, []int64{1}, []uint64{1}},
+		{3, []int64{2, 2}, []uint64{2, 2}},
+		{4, []int64{2}, []uint64{2}},
+		{6, []int64{1, 4}, []uint64{1, 4}},
+		{8, []int64{1, 2, 3}, []uint64{1, 2, 3}},
+		{9, []int64{1, 2, 3}, []uint64{1, 2, 4}},
+		{10, []int64{1}, []uint64{15}},
+	}
+	c.Assert(validator.deltaSchemaInfos, DeepEquals, ret)
+	// Check the flag set by schema diff, note tableID = 3 has been set flag 0x3 in schema version 9, and flag 0x4
+	// in schema version 10, so the resActions for tableID = 3 should be 0x3 & 0x4 = 0x7
+	resTblIDs, resActions, isTablesChanged := validator.isRelatedTablesChanged(5, []int64{1, 3, 4}, true)
+	c.Assert(isTablesChanged, Equals, true)
+	c.Assert(resTblIDs, DeepEquals, []int64{1, 3, 4})
+	c.Assert(resActions, DeepEquals, []uint64{15, 7, 4})
 }

--- a/executor/admin.go
+++ b/executor/admin.go
@@ -390,7 +390,7 @@ func (e *RecoverIndexExec) batchMarkDup(txn kv.Transaction, rows []recoverRows) 
 	for i, key := range e.batchKeys {
 		if val, found := values[string(key)]; found {
 			if distinctFlags[i] {
-				handle, err1 := tables.DecodeHandleInUniqueIndexValueDeprecated(val)
+				handle, err1 := tablecodec.DecodeHandleInUniqueIndexValueDeprecated(val)
 				if err1 != nil {
 					return err1
 				}

--- a/executor/batch_point_get.go
+++ b/executor/batch_point_get.go
@@ -22,7 +22,6 @@ import (
 	"github.com/pingcap/parser/model"
 	"github.com/pingcap/tidb/kv"
 	"github.com/pingcap/tidb/sessionctx/variable"
-	"github.com/pingcap/tidb/table/tables"
 	"github.com/pingcap/tidb/tablecodec"
 	"github.com/pingcap/tidb/types"
 	"github.com/pingcap/tidb/util/chunk"
@@ -189,7 +188,7 @@ func (e *BatchPointGetExec) initialize(ctx context.Context) error {
 			if len(handleVal) == 0 {
 				continue
 			}
-			handle, err1 := tables.DecodeHandleInUniqueIndexValue(handleVal, e.tblInfo.IsCommonHandle)
+			handle, err1 := tablecodec.DecodeHandleInUniqueIndexValue(handleVal, e.tblInfo.IsCommonHandle)
 			if err1 != nil {
 				return err1
 			}

--- a/executor/ddl.go
+++ b/executor/ddl.go
@@ -59,7 +59,7 @@ func (e *DDLExec) toErr(err error) error {
 		logutil.BgLogger().Error("active txn failed", zap.Error(err))
 		return err1
 	}
-	_, _, _, schemaInfoErr := checker.Check(txn.StartTS(), false)
+	_, _, _, _, schemaInfoErr := checker.Check(txn.StartTS(), false)
 	if schemaInfoErr != nil {
 		return errors.Trace(schemaInfoErr)
 	}

--- a/executor/ddl.go
+++ b/executor/ddl.go
@@ -59,7 +59,7 @@ func (e *DDLExec) toErr(err error) error {
 		logutil.BgLogger().Error("active txn failed", zap.Error(err))
 		return err1
 	}
-	schemaInfoErr := checker.Check(txn.StartTS())
+	_, _, _, schemaInfoErr := checker.Check(txn.StartTS(), false)
 	if schemaInfoErr != nil {
 		return errors.Trace(schemaInfoErr)
 	}

--- a/executor/distsql.go
+++ b/executor/distsql.go
@@ -35,7 +35,7 @@ import (
 	"github.com/pingcap/tidb/sessionctx"
 	"github.com/pingcap/tidb/statistics"
 	"github.com/pingcap/tidb/table"
-	"github.com/pingcap/tidb/table/tables"
+	"github.com/pingcap/tidb/tablecodec"
 	"github.com/pingcap/tidb/types"
 	"github.com/pingcap/tidb/util/chunk"
 	"github.com/pingcap/tidb/util/logutil"
@@ -877,7 +877,7 @@ func (w *tableWorker) compareData(ctx context.Context, task *lookupTableTask, ta
 					vals = append(vals, row.GetDatum(i, &col.FieldType))
 				}
 			}
-			vals = tables.TruncateIndexValuesIfNeeded(tblInfo, w.idxLookup.index, vals)
+			vals = tablecodec.TruncateIndexValuesIfNeeded(tblInfo, w.idxLookup.index, vals)
 			for i, val := range vals {
 				col := w.idxTblCols[i]
 				tp := &col.FieldType

--- a/executor/insert.go
+++ b/executor/insert.go
@@ -23,7 +23,6 @@ import (
 	"github.com/pingcap/tidb/expression"
 	"github.com/pingcap/tidb/kv"
 	"github.com/pingcap/tidb/table"
-	"github.com/pingcap/tidb/table/tables"
 	"github.com/pingcap/tidb/tablecodec"
 	"github.com/pingcap/tidb/types"
 	"github.com/pingcap/tidb/util/chunk"
@@ -134,7 +133,7 @@ func prefetchConflictedOldRows(ctx context.Context, txn kv.Transaction, rows []t
 	for _, r := range rows {
 		for _, uk := range r.uniqueKeys {
 			if val, found := values[string(uk.newKV.key)]; found {
-				handle, err := tables.DecodeHandleInUniqueIndexValue(val, uk.commonHandle)
+				handle, err := tablecodec.DecodeHandleInUniqueIndexValue(val, uk.commonHandle)
 				if err != nil {
 					return err
 				}
@@ -217,7 +216,7 @@ func (e *InsertExec) batchUpdateDupRows(ctx context.Context, newRows [][]types.D
 				}
 				return err
 			}
-			handle, err := tables.DecodeHandleInUniqueIndexValue(val, uk.commonHandle)
+			handle, err := tablecodec.DecodeHandleInUniqueIndexValue(val, uk.commonHandle)
 			if err != nil {
 				return err
 			}

--- a/executor/point_get.go
+++ b/executor/point_get.go
@@ -189,7 +189,7 @@ func (e *PointGetExecutor) Next(ctx context.Context, req *chunk.Chunk) error {
 				return e.lockKeyIfNeeded(ctx, e.idxKey)
 			}
 			var iv kv.Handle
-			iv, err = tables.DecodeHandleInUniqueIndexValue(e.handleVal, e.tblInfo.IsCommonHandle)
+			iv, err = tablecodec.DecodeHandleInUniqueIndexValue(e.handleVal, e.tblInfo.IsCommonHandle)
 			if err != nil {
 				return err
 			}

--- a/executor/point_get_test.go
+++ b/executor/point_get_test.go
@@ -25,7 +25,6 @@ import (
 	"github.com/pingcap/tidb/session"
 	"github.com/pingcap/tidb/store/mockstore"
 	"github.com/pingcap/tidb/store/tikv"
-	"github.com/pingcap/tidb/table/tables"
 	"github.com/pingcap/tidb/tablecodec"
 	"github.com/pingcap/tidb/types"
 	"github.com/pingcap/tidb/util/codec"
@@ -527,7 +526,7 @@ func (s *testPointGetSuite) TestReturnValues(c *C) {
 	txnCtx := tk.Se.GetSessionVars().TxnCtx
 	val, ok := txnCtx.GetKeyInPessimisticLockCache(pk)
 	c.Assert(ok, IsTrue)
-	handle, err := tables.DecodeHandleInUniqueIndexValue(val, false)
+	handle, err := tablecodec.DecodeHandleInUniqueIndexValue(val, false)
 	c.Assert(err, IsNil)
 	rowKey := tablecodec.EncodeRowKeyWithHandle(tid, handle)
 	_, ok = txnCtx.GetKeyInPessimisticLockCache(rowKey)

--- a/executor/replace.go
+++ b/executor/replace.go
@@ -20,7 +20,6 @@ import (
 	"github.com/pingcap/errors"
 	"github.com/pingcap/parser/mysql"
 	"github.com/pingcap/tidb/kv"
-	"github.com/pingcap/tidb/table/tables"
 	"github.com/pingcap/tidb/tablecodec"
 	"github.com/pingcap/tidb/types"
 	"github.com/pingcap/tidb/util/chunk"
@@ -154,7 +153,7 @@ func (e *ReplaceExec) removeIndexRow(ctx context.Context, txn kv.Transaction, r 
 			}
 			return false, false, err
 		}
-		handle, err := tables.DecodeHandleInUniqueIndexValue(val, uk.commonHandle)
+		handle, err := tablecodec.DecodeHandleInUniqueIndexValue(val, uk.commonHandle)
 		if err != nil {
 			return false, true, err
 		}

--- a/go.mod
+++ b/go.mod
@@ -19,6 +19,7 @@ require (
 	github.com/grpc-ecosystem/go-grpc-middleware v1.0.1-0.20190118093823-f849b5445de4
 	github.com/juju/errors v0.0.0-20181118221551-089d3ea4e4d5
 	github.com/klauspost/cpuid v1.2.1
+	github.com/ngaut/log v0.0.0-20180314031856-b8e36e7ba5ac
 	github.com/ngaut/pools v0.0.0-20180318154953-b7bc8c42aac7
 	github.com/ngaut/sync2 v0.0.0-20141008032647-7a24ed77b2ef
 	github.com/ngaut/unistore v0.0.0-20200604061006-d8e9dc0ad154

--- a/go.sum
+++ b/go.sum
@@ -372,6 +372,8 @@ github.com/mwitkow/go-conntrack v0.0.0-20161129095857-cc309e4a2223/go.mod h1:qRW
 github.com/ncw/directio v1.0.4 h1:CojwI07mCEmRkajgx42Pf8jyCwTs1ji9/Ij9/PJG12k=
 github.com/ncw/directio v1.0.4/go.mod h1:CKGdcN7StAaqjT7Qack3lAXeX4pjnyc46YeqZH1yWVY=
 github.com/nfnt/resize v0.0.0-20160724205520-891127d8d1b5/go.mod h1:jpp1/29i3P1S/RLdc7JQKbRpFeM1dOBd8T9ki5s+AY8=
+github.com/ngaut/log v0.0.0-20180314031856-b8e36e7ba5ac h1:wyheT2lPXRQqYPWY2IVW5BTLrbqCsnhL61zK2R5goLA=
+github.com/ngaut/log v0.0.0-20180314031856-b8e36e7ba5ac/go.mod h1:ueVCjKQllPmX7uEvCYnZD5b8qjidGf1TCH61arVe4SU=
 github.com/ngaut/pools v0.0.0-20180318154953-b7bc8c42aac7 h1:7KAv7KMGTTqSmYZtNdcNTgsos+vFzULLwyElndwn+5c=
 github.com/ngaut/pools v0.0.0-20180318154953-b7bc8c42aac7/go.mod h1:iWMfgwqYW+e8n5lC/jjNEhwcjbRDpl5NT7n2h+4UNcI=
 github.com/ngaut/sync2 v0.0.0-20141008032647-7a24ed77b2ef h1:K0Fn+DoFqNqktdZtdV3bPQ/0cuYh2H4rkg0tytX/07k=

--- a/session/pessimistic_test.go
+++ b/session/pessimistic_test.go
@@ -1393,7 +1393,7 @@ func (s *testPessimisticSuite) TestPointGetWithDeleteInMem(c *C) {
 func (s *testPessimisticSuite) TestPessimisticTxnWithDDL(c *C) {
 	tk := testkit.NewTestKitWithInit(c, s.store)
 	tk2 := testkit.NewTestKitWithInit(c, s.store)
-	tk.MustExec("drop table if exists uk")
+	tk.MustExec("drop table if exists t1")
 	tk.MustExec("create table t1 (c1 int primary key, c2 int)")
 	tk.MustExec("insert t1 values (1, 77), (2, 88)")
 
@@ -1416,7 +1416,20 @@ func (s *testPessimisticSuite) TestPessimisticTxnWithDDL(c *C) {
 	// other ddls should not succeed
 	tk.MustExec("begin pessimistic")
 	tk.MustExec("insert into t1 values(6)")
-	tk2.MustExec("alter table t1 add index k2(c1)")
+	tk2.MustExec("alter table t1 change column c1 c1 bigint")
 	err := tk.ExecToErr("commit")
 	c.Assert(err, NotNil)
+
+	// Add index basic test
+	tk.MustExec("drop table if exists t1")
+	tk.MustExec("create table t1 (c1 int primary key, c2 int, c3 int)")
+	tk.MustExec("insert t1 values (1, 10, 100), (2, 20, 200)")
+
+	tk.MustExec("begin pessimistic")
+	tk.MustExec("insert into t1 values(3, 30, 300)")
+	tk2.MustExec("alter table t1 add index k2(c2)")
+	tk.MustExec("commit")
+	tk.MustExec("admin check table t1")
+	tk2.MustQuery("select c3, c2 from t1 use index(k2) where c2 = 20").Check(testkit.Rows("200 20"))
+	tk2.MustQuery("select c3, c2 from t1 use index(k2) where c2 = 10").Check(testkit.Rows("100 10"))
 }

--- a/table/tables/index.go
+++ b/table/tables/index.go
@@ -14,15 +14,11 @@
 package tables
 
 import (
-	"bytes"
 	"context"
-	"encoding/binary"
 	"io"
-	"unicode/utf8"
 
 	"github.com/opentracing/opentracing-go"
 	"github.com/pingcap/errors"
-	"github.com/pingcap/parser/charset"
 	"github.com/pingcap/parser/model"
 	"github.com/pingcap/parser/mysql"
 	"github.com/pingcap/tidb/kv"
@@ -32,53 +28,7 @@ import (
 	"github.com/pingcap/tidb/tablecodec"
 	"github.com/pingcap/tidb/types"
 	"github.com/pingcap/tidb/util/codec"
-	"github.com/pingcap/tidb/util/collate"
-	"github.com/pingcap/tidb/util/rowcodec"
 )
-
-// EncodeHandleInUniqueIndexValue encodes handle in data.
-func EncodeHandleInUniqueIndexValue(h kv.Handle, isUntouched bool) []byte {
-	if h.IsInt() {
-		var data [8]byte
-		binary.BigEndian.PutUint64(data[:], uint64(h.IntValue()))
-		return data[:]
-	}
-	var untouchedFlag byte
-	if isUntouched {
-		untouchedFlag = 1
-	}
-	return encodeCommonHandle([]byte{untouchedFlag}, h)
-}
-
-// DecodeHandleInUniqueIndexValue decodes handle in data.
-func DecodeHandleInUniqueIndexValue(data []byte, isCommonHandle bool) (kv.Handle, error) {
-	if !isCommonHandle {
-		dLen := len(data)
-		if dLen <= tablecodec.MaxOldEncodeValueLen {
-			return kv.IntHandle(int64(binary.BigEndian.Uint64(data))), nil
-		}
-		return kv.IntHandle(int64(binary.BigEndian.Uint64(data[dLen-int(data[0]):]))), nil
-	}
-	tailLen := int(data[0])
-	data = data[:len(data)-tailLen]
-	handleLen := uint16(data[2])<<8 + uint16(data[3])
-	handleEndOff := 4 + handleLen
-	h, err := kv.NewCommonHandle(data[4:handleEndOff])
-	if err != nil {
-		return nil, err
-	}
-	return h, nil
-}
-
-// DecodeHandleInUniqueIndexValueDeprecated decodes old handle in data.
-// TODO: remove me after ddl full support cluster index
-func DecodeHandleInUniqueIndexValueDeprecated(data []byte) (int64, error) {
-	dLen := len(data)
-	if dLen <= tablecodec.MaxOldEncodeValueLen {
-		return int64(binary.BigEndian.Uint64(data)), nil
-	}
-	return int64(binary.BigEndian.Uint64(data[dLen-int(data[0]):])), nil
-}
 
 // indexIter is for KV store index iterator.
 type indexIter struct {
@@ -114,7 +64,7 @@ func (c *indexIter) Next() (val []types.Datum, h kv.Handle, err error) {
 		val = vv[0 : len(vv)-1]
 	} else {
 		// If the index is unique and the value isn't nil, the handle is in value.
-		h, err = DecodeHandleInUniqueIndexValue(c.it.Value(), c.idx.tblInfo.IsCommonHandle)
+		h, err = tablecodec.DecodeHandleInUniqueIndexValue(c.it.Value(), c.idx.tblInfo.IsCommonHandle)
 		if err != nil {
 			return nil, nil, err
 		}
@@ -163,81 +113,10 @@ func (c *index) Meta() *model.IndexInfo {
 	return c.idxInfo
 }
 
-func (c *index) getIndexKeyBuf(buf []byte, defaultCap int) []byte {
-	if buf != nil {
-		return buf[:0]
-	}
-
-	return make([]byte, 0, defaultCap)
-}
-
-// TruncateIndexValuesIfNeeded truncates the index values created using only the leading part of column values.
-func TruncateIndexValuesIfNeeded(tblInfo *model.TableInfo, idxInfo *model.IndexInfo, indexedValues []types.Datum) []types.Datum {
-	for i := 0; i < len(indexedValues); i++ {
-		v := &indexedValues[i]
-		if v.Kind() == types.KindString || v.Kind() == types.KindBytes {
-			ic := idxInfo.Columns[i]
-			colCharset := tblInfo.Columns[ic.Offset].Charset
-			colValue := v.GetBytes()
-			isUTF8Charset := colCharset == charset.CharsetUTF8 || colCharset == charset.CharsetUTF8MB4
-			origKind := v.Kind()
-			if isUTF8Charset {
-				if ic.Length != types.UnspecifiedLength && utf8.RuneCount(colValue) > ic.Length {
-					rs := bytes.Runes(colValue)
-					truncateStr := string(rs[:ic.Length])
-					// truncate value and limit its length
-					v.SetString(truncateStr, tblInfo.Columns[ic.Offset].Collate)
-					if origKind == types.KindBytes {
-						v.SetBytes(v.GetBytes())
-					}
-				}
-			} else if ic.Length != types.UnspecifiedLength && len(colValue) > ic.Length {
-				// truncate value and limit its length
-				v.SetBytes(colValue[:ic.Length])
-				if origKind == types.KindString {
-					v.SetString(v.GetString(), tblInfo.Columns[ic.Offset].Collate)
-				}
-			}
-		}
-	}
-
-	return indexedValues
-}
-
 // GenIndexKey generates storage key for index values. Returned distinct indicates whether the
 // indexed values should be distinct in storage (i.e. whether handle is encoded in the key).
 func (c *index) GenIndexKey(sc *stmtctx.StatementContext, indexedValues []types.Datum, h kv.Handle, buf []byte) (key []byte, distinct bool, err error) {
-	if c.idxInfo.Unique {
-		// See https://dev.mysql.com/doc/refman/5.7/en/create-index.html
-		// A UNIQUE index creates a constraint such that all values in the index must be distinct.
-		// An error occurs if you try to add a new row with a key value that matches an existing row.
-		// For all engines, a UNIQUE index permits multiple NULL values for columns that can contain NULL.
-		distinct = true
-		for _, cv := range indexedValues {
-			if cv.IsNull() {
-				distinct = false
-				break
-			}
-		}
-	}
-
-	// For string columns, indexes can be created using only the leading part of column values,
-	// using col_name(length) syntax to specify an index prefix length.
-	indexedValues = TruncateIndexValuesIfNeeded(c.tblInfo, c.idxInfo, indexedValues)
-	key = c.getIndexKeyBuf(buf, len(c.prefix)+len(indexedValues)*9+9)
-	key = append(key, []byte(c.prefix)...)
-	key, err = codec.EncodeKey(sc, key, indexedValues...)
-	if err != nil {
-		return nil, false, err
-	}
-	if !distinct && h != nil {
-		if h.IsInt() {
-			key, err = codec.EncodeKey(sc, key, types.NewDatum(h.IntValue()))
-		} else {
-			key = append(key, h.Encoded()...)
-		}
-	}
-	return
+	return tablecodec.GenIndexKey(sc, c.tblInfo, c.idxInfo, c.prefix, indexedValues, h, buf)
 }
 
 // Create creates a new entry in the kvIndex data.
@@ -360,57 +239,10 @@ func (c *index) Create(sctx sessionctx.Context, rm kv.RetrieverMutator, indexedV
 
 	// save the key buffer to reuse.
 	writeBufs.IndexKeyBuf = key
-	var idxVal []byte
-	if collate.NewCollationEnabled() && c.containNonBinaryString {
-		colIds := make([]int64, len(c.idxInfo.Columns))
-		for i, col := range c.idxInfo.Columns {
-			colIds[i] = c.tblInfo.Columns[col.Offset].ID
-		}
-		rd := rowcodec.Encoder{Enable: true}
-		rowRestoredValue, err := rd.Encode(sctx.GetSessionVars().StmtCtx, colIds, indexedValues, nil)
-		if err != nil {
-			return nil, err
-		}
-		// tailLen(1) + commonHandleFlag(1) + handleLen(2) + handle + restoredValue
-		idxValCap := 1 + 1 + 2 + h.Len() + len(rowRestoredValue)
-		idxVal = make([]byte, 1, idxValCap)
-		if !h.IsInt() && distinct {
-			idxVal = encodeCommonHandle(idxVal, h)
-		}
-		idxVal = append(idxVal, rowRestoredValue...)
-		tailLen := 0
-		if h.IsInt() && distinct {
-			// The len of the idxVal is always >= 10 since len (restoredValue) > 0.
-			tailLen += 8
-			idxVal = append(idxVal, EncodeHandleInUniqueIndexValue(h, false)...)
-		} else if len(idxVal) < 10 {
-			// Padding the len to 10
-			paddingLen := 10 - len(idxVal)
-			tailLen += paddingLen
-			idxVal = append(idxVal, bytes.Repeat([]byte{0x0}, paddingLen)...)
-		}
-		if opt.Untouched {
-			// If index is untouched and fetch here means the key is exists in TiKV, but not in txn mem-buffer,
-			// then should also write the untouched index key/value to mem-buffer to make sure the data
-			// is consistent with the index in txn mem-buffer.
-			tailLen += 1
-			idxVal = append(idxVal, kv.UnCommitIndexKVFlag)
-		}
-		idxVal[0] = byte(tailLen)
-	} else {
-		idxVal = make([]byte, 0)
-		if distinct {
-			idxVal = EncodeHandleInUniqueIndexValue(h, opt.Untouched)
-		}
-		if opt.Untouched {
-			// If index is untouched and fetch here means the key is exists in TiKV, but not in txn mem-buffer,
-			// then should also write the untouched index key/value to mem-buffer to make sure the data
-			// is consistent with the index in txn mem-buffer.
-			idxVal = append(idxVal, kv.UnCommitIndexKVFlag)
-		}
-		if len(idxVal) == 0 {
-			idxVal = []byte{'0'}
-		}
+	idxVal, err := tablecodec.GenIndexValue(sctx.GetSessionVars().StmtCtx, c.tblInfo, c.idxInfo,
+		c.containNonBinaryString, distinct, opt.Untouched, indexedValues, h)
+	if err != nil {
+		return nil, err
 	}
 
 	if !distinct || skipCheck || opt.Untouched {
@@ -437,19 +269,11 @@ func (c *index) Create(sctx sessionctx.Context, rm kv.RetrieverMutator, indexedV
 		return nil, err
 	}
 
-	handle, err := DecodeHandleInUniqueIndexValue(value, c.tblInfo.IsCommonHandle)
+	handle, err := tablecodec.DecodeHandleInUniqueIndexValue(value, c.tblInfo.IsCommonHandle)
 	if err != nil {
 		return nil, err
 	}
 	return handle, kv.ErrKeyExists
-}
-
-func encodeCommonHandle(idxVal []byte, h kv.Handle) []byte {
-	idxVal = append(idxVal, tablecodec.CommonHandleFlag)
-	hLen := uint16(len(h.Encoded()))
-	idxVal = append(idxVal, byte(hLen>>8), byte(hLen))
-	idxVal = append(idxVal, h.Encoded()...)
-	return idxVal
 }
 
 // Delete removes the entry for handle h and indexdValues from KV index.
@@ -534,7 +358,7 @@ func (c *index) Exist(sc *stmtctx.StatementContext, rm kv.RetrieverMutator, inde
 	// For distinct index, the value of key is handle.
 	if distinct {
 		var handle kv.Handle
-		handle, err := DecodeHandleInUniqueIndexValue(value, c.tblInfo.IsCommonHandle)
+		handle, err := tablecodec.DecodeHandleInUniqueIndexValue(value, c.tblInfo.IsCommonHandle)
 		if err != nil {
 			return false, nil, err
 		}

--- a/tablecodec/tablecodec.go
+++ b/tablecodec/tablecodec.go
@@ -1001,7 +1001,7 @@ func GenIndexValue(sc *stmtctx.StatementContext, tblInfo *model.TableInfo, idxIn
 		idxValCap := 1 + 1 + 2 + h.Len() + len(rowRestoredValue)
 		idxVal = make([]byte, 1, idxValCap)
 		if !h.IsInt() && distinct {
-			idxVal = encodeCommonHandle(idxVal, h)
+			idxVal = EncodeCommonHandle(idxVal, h)
 		}
 		idxVal = append(idxVal, rowRestoredValue...)
 		tailLen := 0
@@ -1085,10 +1085,11 @@ func EncodeHandleInUniqueIndexValue(h kv.Handle, isUntouched bool) []byte {
 	if isUntouched {
 		untouchedFlag = 1
 	}
-	return encodeCommonHandle([]byte{untouchedFlag}, h)
+	return EncodeCommonHandle([]byte{untouchedFlag}, h)
 }
 
-func encodeCommonHandle(idxVal []byte, h kv.Handle) []byte {
+// EncodeCommonHandle encodes handle key
+func EncodeCommonHandle(idxVal []byte, h kv.Handle) []byte {
 	idxVal = append(idxVal, CommonHandleFlag)
 	hLen := uint16(len(h.Encoded()))
 	idxVal = append(idxVal, byte(hLen>>8), byte(hLen))


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/tidb/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->



### What is changed and how it works?

DDL related changes:
1. Record schema change action types for each schema diff, we can know whether a table has unsupported changes without comparing the whole `model.TableInfo` object.

2PC related changes:
1. Add `getAll` field for schema check, if `getAll` flag is true, try to get all schema change action types for each related table, and return if it's amendable for these schema change types.
2. If changes are amendable, try to diff two `model.TableInfo` using two schema meta with `startTS` and `commitTS`. Check every index in new and old table, then generate index change related amend operations.
3. Try to amend these operations, using `Txn.BatchGet` to fetch oldRows,  generate index keys and values based on operation type, then generate new mutations which need prewrite, and old mutations which need rollback
4. Amend mutations in `twoPhaseCommiter` and then try to commit


### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test


Code changes



Side effects



Related changes

