### PR TITLE
[draft] try to amend add index schema change for pessimistic txn commit

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -214,7 +214,7 @@ endif
 
 server:
 ifeq ($(TARGET), "")
-	CGO_ENABLED=1 $(GOBUILD) $(RACE_FLAG) -ldflags '$(LDFLAGS) $(CHECK_FLAG)' -o bin/tidb-server tidb-server/main.go
+	CGO_ENABLED=1 $(GOBUILD) $(RACE_FLAG) -ldflags '$(LDFLAGS) $(CHECK_FLAG)' -gcflags="all=-N -l" -o bin/tidb-server tidb-server/main.go
 else
 	CGO_ENABLED=1 $(GOBUILD) $(RACE_FLAG) -ldflags '$(LDFLAGS) $(CHECK_FLAG)' -o '$(TARGET)' tidb-server/main.go
 endif

--- a/domain/domain.go
+++ b/domain/domain.go
@@ -81,14 +81,14 @@ type Domain struct {
 // loadInfoSchema loads infoschema at startTS into handle, usedSchemaVersion is the currently used
 // infoschema version, if it is the same as the schema version at startTS, we don't need to reload again.
 // It returns the latest schema version, the changed table IDs, whether it's a full load and an error.
-func (do *Domain) loadInfoSchema(handle *infoschema.Handle, usedSchemaVersion int64, startTS uint64) (int64, []int64, []uint64, bool, error) {
-	var fullLoad bool
+func (do *Domain) loadInfoSchema(handle *infoschema.Handle, usedSchemaVersion int64,
+	startTS uint64) (neededSchemaVersion int64, tblIDs []int64, actionTypes []uint64, fullLoad bool, err error) {
 	snapshot, err := do.store.GetSnapshot(kv.NewVersion(startTS))
 	if err != nil {
 		return 0, nil, nil, fullLoad, err
 	}
 	m := meta.NewSnapshotMeta(snapshot)
-	neededSchemaVersion, err := m.GetSchemaVersion()
+	neededSchemaVersion, err = m.GetSchemaVersion()
 	if err != nil {
 		return 0, nil, nil, fullLoad, err
 	}

--- a/domain/domain.go
+++ b/domain/domain.go
@@ -82,18 +82,18 @@ type Domain struct {
 // infoschema version, if it is the same as the schema version at startTS, we don't need to reload again.
 // It returns the latest schema version, the changed table IDs, whether it's a full load and an error.
 func (do *Domain) loadInfoSchema(handle *infoschema.Handle, usedSchemaVersion int64,
-	startTS uint64) (neededSchemaVersion int64, tblIDs []int64, actionTypes []uint64, fullLoad bool, err error) {
+	startTS uint64) (neededSchemaVersion int64, change *relatedSchemaChange, fullLoad bool, err error) {
 	snapshot, err := do.store.GetSnapshot(kv.NewVersion(startTS))
 	if err != nil {
-		return 0, nil, nil, fullLoad, err
+		return 0, nil, fullLoad, err
 	}
 	m := meta.NewSnapshotMeta(snapshot)
 	neededSchemaVersion, err = m.GetSchemaVersion()
 	if err != nil {
-		return 0, nil, nil, fullLoad, err
+		return 0, nil, fullLoad, err
 	}
 	if usedSchemaVersion != 0 && usedSchemaVersion == neededSchemaVersion {
-		return neededSchemaVersion, nil, nil, fullLoad, nil
+		return neededSchemaVersion, nil, fullLoad, nil
 	}
 
 	// Update self schema version to etcd.
@@ -117,7 +117,7 @@ func (do *Domain) loadInfoSchema(handle *infoschema.Handle, usedSchemaVersion in
 	}()
 
 	startTime := time.Now()
-	ok, tblIDs, actions, err := do.tryLoadSchemaDiffs(m, usedSchemaVersion, neededSchemaVersion)
+	ok, relatedChanges, err := do.tryLoadSchemaDiffs(m, usedSchemaVersion, neededSchemaVersion)
 	if err != nil {
 		// We can fall back to full load, don't need to return the error.
 		logutil.BgLogger().Error("failed to load schema diff", zap.Error(err))
@@ -127,26 +127,26 @@ func (do *Domain) loadInfoSchema(handle *infoschema.Handle, usedSchemaVersion in
 			zap.Int64("usedSchemaVersion", usedSchemaVersion),
 			zap.Int64("neededSchemaVersion", neededSchemaVersion),
 			zap.Duration("start time", time.Since(startTime)),
-			zap.Int64s("tblIDs", tblIDs))
-		return neededSchemaVersion, tblIDs, actions, fullLoad, nil
+			zap.Int64s("tblIDs", relatedChanges.tblIDS))
+		return neededSchemaVersion, relatedChanges, fullLoad, nil
 	}
 
 	fullLoad = true
 	schemas, err := do.fetchAllSchemasWithTables(m)
 	if err != nil {
-		return 0, nil, nil, fullLoad, err
+		return 0, nil, fullLoad, err
 	}
 
 	newISBuilder, err := infoschema.NewBuilder(handle).InitWithDBInfos(schemas, neededSchemaVersion)
 	if err != nil {
-		return 0, nil, nil, fullLoad, err
+		return 0, nil, fullLoad, err
 	}
 	logutil.BgLogger().Info("full load InfoSchema success",
 		zap.Int64("usedSchemaVersion", usedSchemaVersion),
 		zap.Int64("neededSchemaVersion", neededSchemaVersion),
 		zap.Duration("start time", time.Since(startTime)))
 	newISBuilder.Build()
-	return neededSchemaVersion, nil, nil, fullLoad, nil
+	return neededSchemaVersion, nil, fullLoad, nil
 }
 
 func (do *Domain) fetchAllSchemasWithTables(m *meta.Meta) ([]*model.DBInfo, error) {
@@ -230,36 +230,43 @@ func isTooOldSchema(usedVersion, newVersion int64) bool {
 	return false
 }
 
+type relatedSchemaChange struct {
+	dbIDs       []int64
+	tblIDS      []int64
+	actionTypes []uint64
+}
+
 // tryLoadSchemaDiffs tries to only load latest schema changes.
 // Return true if the schema is loaded successfully.
 // Return false if the schema can not be loaded by schema diff, then we need to do full load.
 // The second returned value is the delta updated table and partition IDs.
-func (do *Domain) tryLoadSchemaDiffs(m *meta.Meta, usedVersion, newVersion int64) (bool, []int64, []uint64, error) {
+func (do *Domain) tryLoadSchemaDiffs(m *meta.Meta, usedVersion, newVersion int64) (bool, *relatedSchemaChange, error) {
 	// If there isn't any used version, or used version is too old, we do full load.
 	// And when users use history read feature, we will set usedVersion to initialVersion, then full load is needed.
 	if isTooOldSchema(usedVersion, newVersion) {
-		return false, nil, nil, nil
+		return false, nil, nil
 	}
 	var diffs []*model.SchemaDiff
 	for usedVersion < newVersion {
 		usedVersion++
 		diff, err := m.GetSchemaDiff(usedVersion)
 		if err != nil {
-			return false, nil, nil, err
+			return false, nil, err
 		}
 		if diff == nil {
 			// If diff is missing for any version between used and new version, we fall back to full reload.
-			return false, nil, nil, nil
+			return false, nil, nil
 		}
 		diffs = append(diffs, diff)
 	}
 	builder := infoschema.NewBuilder(do.infoHandle).InitWithOldInfoSchema()
+	dbIDs := make([]int64, 0, len(diffs))
 	tblIDs := make([]int64, 0, len(diffs))
 	actions := make([]uint64, 0, len(diffs))
 	for _, diff := range diffs {
 		ids, err := builder.ApplyDiff(m, diff)
 		if err != nil {
-			return false, nil, nil, err
+			return false, nil, err
 		}
 		if canSkipSchemaCheckerDDL(diff.Type) {
 			continue
@@ -267,10 +274,16 @@ func (do *Domain) tryLoadSchemaDiffs(m *meta.Meta, usedVersion, newVersion int64
 		tblIDs = append(tblIDs, ids...)
 		for i := 0; i < len(ids); i++ {
 			actions = append(actions, uint64(1<<diff.Type))
+			dbIDs = append(dbIDs, diff.SchemaID)
 		}
 	}
 	builder.Build()
-	return true, tblIDs, actions, nil
+	res := &relatedSchemaChange{
+		dbIDs:       dbIDs,
+		tblIDS:      tblIDs,
+		actionTypes: actions,
+	}
+	return true, res, nil
 }
 
 func canSkipSchemaCheckerDDL(tp model.ActionType) bool {
@@ -290,7 +303,7 @@ func (do *Domain) InfoSchema() infoschema.InfoSchema {
 func (do *Domain) GetSnapshotInfoSchema(snapshotTS uint64) (infoschema.InfoSchema, error) {
 	snapHandle := do.infoHandle.EmptyClone()
 	// For the snapHandle, it's an empty Handle, so its usedSchemaVersion is initialVersion.
-	_, _, _, _, err := do.loadInfoSchema(snapHandle, initialVersion, snapshotTS)
+	_, _, _, err := do.loadInfoSchema(snapHandle, initialVersion, snapshotTS)
 	if err != nil {
 		return nil, err
 	}
@@ -357,11 +370,10 @@ func (do *Domain) Reload() error {
 	}
 
 	var (
-		fullLoad                bool
-		changedPhysicalTableIDs []int64
-		changedActionTypes      []uint64
+		fullLoad       bool
+		relatedChanges *relatedSchemaChange
 	)
-	neededSchemaVersion, changedPhysicalTableIDs, changedActionTypes, fullLoad, err = do.loadInfoSchema(do.infoHandle, schemaVersion, ver.Ver)
+	neededSchemaVersion, relatedChanges, fullLoad, err = do.loadInfoSchema(do.infoHandle, schemaVersion, ver.Ver)
 	metrics.LoadSchemaDuration.Observe(time.Since(startTime).Seconds())
 	if err != nil {
 		metrics.LoadSchemaCounter.WithLabelValues("failed").Inc()
@@ -373,7 +385,7 @@ func (do *Domain) Reload() error {
 		logutil.BgLogger().Info("full load and reset schema validator")
 		do.SchemaValidator.Reset()
 	}
-	do.SchemaValidator.Update(ver.Ver, schemaVersion, neededSchemaVersion, changedPhysicalTableIDs, changedActionTypes)
+	do.SchemaValidator.Update(ver.Ver, schemaVersion, neededSchemaVersion, relatedChanges)
 
 	lease := do.DDL().GetLease()
 	sub := time.Since(startTime)

--- a/domain/domain.go
+++ b/domain/domain.go
@@ -81,19 +81,19 @@ type Domain struct {
 // loadInfoSchema loads infoschema at startTS into handle, usedSchemaVersion is the currently used
 // infoschema version, if it is the same as the schema version at startTS, we don't need to reload again.
 // It returns the latest schema version, the changed table IDs, whether it's a full load and an error.
-func (do *Domain) loadInfoSchema(handle *infoschema.Handle, usedSchemaVersion int64, startTS uint64) (int64, []int64, bool, error) {
+func (do *Domain) loadInfoSchema(handle *infoschema.Handle, usedSchemaVersion int64, startTS uint64) (int64, []int64, []uint64, bool, error) {
 	var fullLoad bool
 	snapshot, err := do.store.GetSnapshot(kv.NewVersion(startTS))
 	if err != nil {
-		return 0, nil, fullLoad, err
+		return 0, nil, nil, fullLoad, err
 	}
 	m := meta.NewSnapshotMeta(snapshot)
 	neededSchemaVersion, err := m.GetSchemaVersion()
 	if err != nil {
-		return 0, nil, fullLoad, err
+		return 0, nil, nil, fullLoad, err
 	}
 	if usedSchemaVersion != 0 && usedSchemaVersion == neededSchemaVersion {
-		return neededSchemaVersion, nil, fullLoad, nil
+		return neededSchemaVersion, nil, nil, fullLoad, nil
 	}
 
 	// Update self schema version to etcd.
@@ -117,7 +117,7 @@ func (do *Domain) loadInfoSchema(handle *infoschema.Handle, usedSchemaVersion in
 	}()
 
 	startTime := time.Now()
-	ok, tblIDs, err := do.tryLoadSchemaDiffs(m, usedSchemaVersion, neededSchemaVersion)
+	ok, tblIDs, actions, err := do.tryLoadSchemaDiffs(m, usedSchemaVersion, neededSchemaVersion)
 	if err != nil {
 		// We can fall back to full load, don't need to return the error.
 		logutil.BgLogger().Error("failed to load schema diff", zap.Error(err))
@@ -128,25 +128,25 @@ func (do *Domain) loadInfoSchema(handle *infoschema.Handle, usedSchemaVersion in
 			zap.Int64("neededSchemaVersion", neededSchemaVersion),
 			zap.Duration("start time", time.Since(startTime)),
 			zap.Int64s("tblIDs", tblIDs))
-		return neededSchemaVersion, tblIDs, fullLoad, nil
+		return neededSchemaVersion, tblIDs, actions, fullLoad, nil
 	}
 
 	fullLoad = true
 	schemas, err := do.fetchAllSchemasWithTables(m)
 	if err != nil {
-		return 0, nil, fullLoad, err
+		return 0, nil, nil, fullLoad, err
 	}
 
 	newISBuilder, err := infoschema.NewBuilder(handle).InitWithDBInfos(schemas, neededSchemaVersion)
 	if err != nil {
-		return 0, nil, fullLoad, err
+		return 0, nil, nil, fullLoad, err
 	}
 	logutil.BgLogger().Info("full load InfoSchema success",
 		zap.Int64("usedSchemaVersion", usedSchemaVersion),
 		zap.Int64("neededSchemaVersion", neededSchemaVersion),
 		zap.Duration("start time", time.Since(startTime)))
 	newISBuilder.Build()
-	return neededSchemaVersion, nil, fullLoad, nil
+	return neededSchemaVersion, nil, nil, fullLoad, nil
 }
 
 func (do *Domain) fetchAllSchemasWithTables(m *meta.Meta) ([]*model.DBInfo, error) {
@@ -234,39 +234,43 @@ func isTooOldSchema(usedVersion, newVersion int64) bool {
 // Return true if the schema is loaded successfully.
 // Return false if the schema can not be loaded by schema diff, then we need to do full load.
 // The second returned value is the delta updated table and partition IDs.
-func (do *Domain) tryLoadSchemaDiffs(m *meta.Meta, usedVersion, newVersion int64) (bool, []int64, error) {
+func (do *Domain) tryLoadSchemaDiffs(m *meta.Meta, usedVersion, newVersion int64) (bool, []int64, []uint64, error) {
 	// If there isn't any used version, or used version is too old, we do full load.
 	// And when users use history read feature, we will set usedVersion to initialVersion, then full load is needed.
 	if isTooOldSchema(usedVersion, newVersion) {
-		return false, nil, nil
+		return false, nil, nil, nil
 	}
 	var diffs []*model.SchemaDiff
 	for usedVersion < newVersion {
 		usedVersion++
 		diff, err := m.GetSchemaDiff(usedVersion)
 		if err != nil {
-			return false, nil, err
+			return false, nil, nil, err
 		}
 		if diff == nil {
 			// If diff is missing for any version between used and new version, we fall back to full reload.
-			return false, nil, nil
+			return false, nil, nil, nil
 		}
 		diffs = append(diffs, diff)
 	}
 	builder := infoschema.NewBuilder(do.infoHandle).InitWithOldInfoSchema()
 	tblIDs := make([]int64, 0, len(diffs))
+	actions := make([]uint64, 0, len(diffs))
 	for _, diff := range diffs {
 		ids, err := builder.ApplyDiff(m, diff)
 		if err != nil {
-			return false, nil, err
+			return false, nil, nil, err
 		}
 		if canSkipSchemaCheckerDDL(diff.Type) {
 			continue
 		}
 		tblIDs = append(tblIDs, ids...)
+		for i := 0; i < len(ids); i++ {
+			actions = append(actions, uint64(1<<diff.Type))
+		}
 	}
 	builder.Build()
-	return true, tblIDs, nil
+	return true, tblIDs, actions, nil
 }
 
 func canSkipSchemaCheckerDDL(tp model.ActionType) bool {
@@ -286,7 +290,7 @@ func (do *Domain) InfoSchema() infoschema.InfoSchema {
 func (do *Domain) GetSnapshotInfoSchema(snapshotTS uint64) (infoschema.InfoSchema, error) {
 	snapHandle := do.infoHandle.EmptyClone()
 	// For the snapHandle, it's an empty Handle, so its usedSchemaVersion is initialVersion.
-	_, _, _, err := do.loadInfoSchema(snapHandle, initialVersion, snapshotTS)
+	_, _, _, _, err := do.loadInfoSchema(snapHandle, initialVersion, snapshotTS)
 	if err != nil {
 		return nil, err
 	}
@@ -355,8 +359,9 @@ func (do *Domain) Reload() error {
 	var (
 		fullLoad                bool
 		changedPhysicalTableIDs []int64
+		changedActionTypes      []uint64
 	)
-	neededSchemaVersion, changedPhysicalTableIDs, fullLoad, err = do.loadInfoSchema(do.infoHandle, schemaVersion, ver.Ver)
+	neededSchemaVersion, changedPhysicalTableIDs, changedActionTypes, fullLoad, err = do.loadInfoSchema(do.infoHandle, schemaVersion, ver.Ver)
 	metrics.LoadSchemaDuration.Observe(time.Since(startTime).Seconds())
 	if err != nil {
 		metrics.LoadSchemaCounter.WithLabelValues("failed").Inc()
@@ -368,7 +373,7 @@ func (do *Domain) Reload() error {
 		logutil.BgLogger().Info("full load and reset schema validator")
 		do.SchemaValidator.Reset()
 	}
-	do.SchemaValidator.Update(ver.Ver, schemaVersion, neededSchemaVersion, changedPhysicalTableIDs)
+	do.SchemaValidator.Update(ver.Ver, schemaVersion, neededSchemaVersion, changedPhysicalTableIDs, changedActionTypes)
 
 	lease := do.DDL().GetLease()
 	sub := time.Since(startTime)

--- a/domain/domain_test.go
+++ b/domain/domain_test.go
@@ -314,24 +314,24 @@ func (*testSuite) TestT(c *C) {
 	c.Assert(err, IsNil)
 	ts := ver.Ver
 
-	succ := dom.SchemaValidator.Check(ts, schemaVer, nil)
+	_, _, succ := dom.SchemaValidator.Check(ts, schemaVer, nil, false)
 	c.Assert(succ, Equals, ResultSucc)
 	c.Assert(failpoint.Enable("github.com/pingcap/tidb/domain/ErrorMockReloadFailed", `return(true)`), IsNil)
 	err = dom.Reload()
 	c.Assert(err, NotNil)
-	succ = dom.SchemaValidator.Check(ts, schemaVer, nil)
+	_, _, succ = dom.SchemaValidator.Check(ts, schemaVer, nil, false)
 	c.Assert(succ, Equals, ResultSucc)
 	time.Sleep(ddlLease)
 
 	ver, err = store.CurrentVersion()
 	c.Assert(err, IsNil)
 	ts = ver.Ver
-	succ = dom.SchemaValidator.Check(ts, schemaVer, nil)
+	_, _, succ = dom.SchemaValidator.Check(ts, schemaVer, nil, false)
 	c.Assert(succ, Equals, ResultUnknown)
 	c.Assert(failpoint.Disable("github.com/pingcap/tidb/domain/ErrorMockReloadFailed"), IsNil)
 	err = dom.Reload()
 	c.Assert(err, IsNil)
-	succ = dom.SchemaValidator.Check(ts, schemaVer, nil)
+	_, _, succ = dom.SchemaValidator.Check(ts, schemaVer, nil, false)
 	c.Assert(succ, Equals, ResultSucc)
 
 	// For slow query.
@@ -396,7 +396,7 @@ func (*testSuite) TestT(c *C) {
 		SchemaOutOfDateRetryInterval = originalRetryInterval
 	}()
 	dom.SchemaValidator.Stop()
-	err = schemaChecker.Check(uint64(123456))
+	_, _, _, err = schemaChecker.Check(uint64(123456), false)
 	c.Assert(err.Error(), Equals, ErrInfoSchemaExpired.Error())
 	dom.SchemaValidator.Reset()
 

--- a/domain/schema_checker.go
+++ b/domain/schema_checker.go
@@ -44,22 +44,23 @@ func NewSchemaChecker(do *Domain, schemaVer int64, relatedTableIDs []int64) *Sch
 }
 
 // Check checks the validity of the schema version.
-func (s *SchemaChecker) Check(txnTS uint64) error {
+func (s *SchemaChecker) Check(txnTS uint64, getAllChangedInfo bool) ([]int64, []uint64, bool, error) {
 	schemaOutOfDateRetryInterval := atomic.LoadInt64(&SchemaOutOfDateRetryInterval)
 	schemaOutOfDateRetryTimes := int(atomic.LoadInt32(&SchemaOutOfDateRetryTimes))
 	for i := 0; i < schemaOutOfDateRetryTimes; i++ {
-		result := s.SchemaValidator.Check(txnTS, s.schemaVer, s.relatedTableIDs)
-		switch result {
+		tblIDs, typeActions, CheckResult := s.SchemaValidator.Check(txnTS, s.schemaVer, s.relatedTableIDs, getAllChangedInfo)
+		switch CheckResult {
 		case ResultSucc:
-			return nil
+			return nil, nil, false, nil
 		case ResultFail:
 			metrics.SchemaLeaseErrorCounter.WithLabelValues("changed").Inc()
-			return ErrInfoSchemaChanged
+			amendable := getAllChangedInfo && (len(tblIDs) > 0)
+			return tblIDs, typeActions, amendable, ErrInfoSchemaChanged
 		case ResultUnknown:
 			time.Sleep(time.Duration(schemaOutOfDateRetryInterval))
 		}
 
 	}
 	metrics.SchemaLeaseErrorCounter.WithLabelValues("outdated").Inc()
-	return ErrInfoSchemaExpired
+	return nil, nil, false, ErrInfoSchemaExpired
 }

--- a/domain/schema_checker_test.go
+++ b/domain/schema_checker_test.go
@@ -27,38 +27,38 @@ func (s *testSuite) TestSchemaCheckerSimple(c *C) {
 
 	// Add some schema versions and delta table IDs.
 	ts := uint64(time.Now().UnixNano())
-	validator.Update(ts, 0, 2, []int64{1})
-	validator.Update(ts, 2, 4, []int64{2})
+	validator.Update(ts, 0, 2, []int64{1}, []uint64{1})
+	validator.Update(ts, 2, 4, []int64{2}, []uint64{2})
 
 	// checker's schema version is the same as the current schema version.
 	checker.schemaVer = 4
-	err := checker.Check(ts)
+	_, _, _, err := checker.Check(ts, false)
 	c.Assert(err, IsNil)
 
 	// checker's schema version is less than the current schema version, and it doesn't exist in validator's items.
 	// checker's related table ID isn't in validator's changed table IDs.
 	checker.schemaVer = 2
 	checker.relatedTableIDs = []int64{3}
-	err = checker.Check(ts)
+	_, _, _, err = checker.Check(ts, false)
 	c.Assert(err, IsNil)
 	// The checker's schema version isn't in validator's items.
 	checker.schemaVer = 1
 	checker.relatedTableIDs = []int64{3}
-	err = checker.Check(ts)
+	_, _, _, err = checker.Check(ts, false)
 	c.Assert(terror.ErrorEqual(err, ErrInfoSchemaChanged), IsTrue)
 	// checker's related table ID is in validator's changed table IDs.
 	checker.relatedTableIDs = []int64{2}
-	err = checker.Check(ts)
+	_, _, _, err = checker.Check(ts, false)
 	c.Assert(terror.ErrorEqual(err, ErrInfoSchemaChanged), IsTrue)
 
 	// validator's latest schema version is expired.
 	time.Sleep(lease + time.Microsecond)
 	checker.schemaVer = 4
 	checker.relatedTableIDs = []int64{3}
-	err = checker.Check(ts)
+	_, _, _, err = checker.Check(ts, false)
 	c.Assert(err, IsNil)
 	nowTS := uint64(time.Now().UnixNano())
 	// Use checker.SchemaValidator.Check instead of checker.Check here because backoff make CI slow.
-	result := checker.SchemaValidator.Check(nowTS, checker.schemaVer, checker.relatedTableIDs)
+	_, _, result := checker.SchemaValidator.Check(nowTS, checker.schemaVer, checker.relatedTableIDs, false)
 	c.Assert(result, Equals, ResultUnknown)
 }

--- a/domain/schema_validator_test.go
+++ b/domain/schema_validator_test.go
@@ -49,36 +49,36 @@ func (*testSuite) TestSchemaValidator(c *C) {
 		time.Sleep(delay)
 		// Reload can run arbitrarily, at any time.
 		item := <-leaseGrantCh
-		validator.Update(item.leaseGrantTS, item.oldVer, item.schemaVer, nil)
+		validator.Update(item.leaseGrantTS, item.oldVer, item.schemaVer, nil, nil)
 	}
 
 	// Take a lease, check it's valid.
 	item := <-leaseGrantCh
-	validator.Update(item.leaseGrantTS, item.oldVer, item.schemaVer, []int64{10})
-	valid := validator.Check(item.leaseGrantTS, item.schemaVer, []int64{10})
+	validator.Update(item.leaseGrantTS, item.oldVer, item.schemaVer, []int64{10}, []uint64{10})
+	_, _, valid := validator.Check(item.leaseGrantTS, item.schemaVer, []int64{10}, false)
 	c.Assert(valid, Equals, ResultSucc)
 
 	// Stop the validator, validator's items value is nil.
 	validator.Stop()
 	c.Assert(validator.IsStarted(), IsFalse)
-	isTablesChanged := validator.isRelatedTablesChanged(item.schemaVer, []int64{10})
+	_, _, isTablesChanged := validator.isRelatedTablesChanged(item.schemaVer, []int64{10}, false)
 	c.Assert(isTablesChanged, IsTrue)
-	valid = validator.Check(item.leaseGrantTS, item.schemaVer, []int64{10})
+	_, _, valid = validator.Check(item.leaseGrantTS, item.schemaVer, []int64{10}, false)
 	c.Assert(valid, Equals, ResultUnknown)
 	validator.Restart()
 
 	// Increase the current time by 2 leases, check schema is invalid.
 	ts := uint64(time.Now().Add(2 * lease).UnixNano()) // Make sure that ts has timed out a lease.
-	valid = validator.Check(ts, item.schemaVer, []int64{10})
+	_, _, valid = validator.Check(ts, item.schemaVer, []int64{10}, false)
 	c.Assert(valid, Equals, ResultUnknown, Commentf("validator latest schema ver %v, time %v, item schema ver %v, ts %v",
 		validator.latestSchemaVer, validator.latestSchemaExpire, 0, oracle.GetTimeFromTS(ts)))
 	// Make sure newItem's version is greater than item.schema.
 	newItem := getGreaterVersionItem(c, lease, leaseGrantCh, item.schemaVer)
 	currVer := newItem.schemaVer
-	validator.Update(newItem.leaseGrantTS, newItem.oldVer, currVer, nil)
-	valid = validator.Check(ts, item.schemaVer, nil)
+	validator.Update(newItem.leaseGrantTS, newItem.oldVer, currVer, nil, nil)
+	_, _, valid = validator.Check(ts, item.schemaVer, nil, false)
 	c.Assert(valid, Equals, ResultFail, Commentf("currVer %d, newItem %v", currVer, item))
-	valid = validator.Check(ts, item.schemaVer, []int64{0})
+	_, _, valid = validator.Check(ts, item.schemaVer, []int64{0}, false)
 	c.Assert(valid, Equals, ResultFail, Commentf("currVer %d, newItem %v", currVer, item))
 	// Check the latest schema version must changed.
 	c.Assert(item.schemaVer, Less, validator.latestSchemaVer)
@@ -86,20 +86,20 @@ func (*testSuite) TestSchemaValidator(c *C) {
 	// Make sure newItem's version is greater than currVer.
 	newItem = getGreaterVersionItem(c, lease, leaseGrantCh, currVer)
 	// Update current schema version to newItem's version and the delta table IDs is 1, 2, 3.
-	validator.Update(ts, currVer, newItem.schemaVer, []int64{1, 2, 3})
+	validator.Update(ts, currVer, newItem.schemaVer, []int64{1, 2, 3}, []uint64{1, 2, 3})
 	// Make sure the updated table IDs don't be covered with the same schema version.
-	validator.Update(ts, newItem.schemaVer, newItem.schemaVer, nil)
-	isTablesChanged = validator.isRelatedTablesChanged(currVer, nil)
+	validator.Update(ts, newItem.schemaVer, newItem.schemaVer, nil, nil)
+	_, _, isTablesChanged = validator.isRelatedTablesChanged(currVer, nil, false)
 	c.Assert(isTablesChanged, IsFalse)
-	isTablesChanged = validator.isRelatedTablesChanged(currVer, []int64{2})
+	_, _, isTablesChanged = validator.isRelatedTablesChanged(currVer, []int64{2}, false)
 	c.Assert(isTablesChanged, IsTrue, Commentf("currVer %d, newItem %v", currVer, newItem))
 	// The current schema version is older than the oldest schema version.
-	isTablesChanged = validator.isRelatedTablesChanged(-1, nil)
+	_, _, isTablesChanged = validator.isRelatedTablesChanged(-1, nil, false)
 	c.Assert(isTablesChanged, IsTrue, Commentf("currVer %d, newItem %v", currVer, newItem))
 
 	// All schema versions is expired.
 	ts = uint64(time.Now().Add(2 * lease).UnixNano())
-	valid = validator.Check(ts, newItem.schemaVer, nil)
+	_, _, valid = validator.Check(ts, newItem.schemaVer, nil, false)
 	c.Assert(valid, Equals, ResultUnknown)
 
 	close(exit)
@@ -155,51 +155,100 @@ func (*testSuite) TestEnqueue(c *C) {
 	c.Assert(validator.IsStarted(), IsTrue)
 	// maxCnt is 0.
 	variable.SetMaxDeltaSchemaCount(0)
-	validator.enqueue(1, []int64{11})
+	validator.enqueue(1, []int64{11}, []uint64{11})
 	c.Assert(validator.deltaSchemaInfos, HasLen, 0)
 
 	// maxCnt is 10.
 	variable.SetMaxDeltaSchemaCount(10)
 	ds := []deltaSchemaInfo{
-		{0, []int64{1}},
-		{1, []int64{1}},
-		{2, []int64{1}},
-		{3, []int64{2, 2}},
-		{4, []int64{2}},
-		{5, []int64{1, 4}},
-		{6, []int64{1, 4}},
-		{7, []int64{3, 1, 3}},
-		{8, []int64{1, 2, 3}},
-		{9, []int64{1, 2, 3}},
+		{0, []int64{1}, []uint64{1}},
+		{1, []int64{1}, []uint64{1}},
+		{2, []int64{1}, []uint64{1}},
+		{3, []int64{2, 2}, []uint64{2, 2}},
+		{4, []int64{2}, []uint64{2}},
+		{5, []int64{1, 4}, []uint64{1, 4}},
+		{6, []int64{1, 4}, []uint64{1, 4}},
+		{7, []int64{3, 1, 3}, []uint64{3, 1, 3}},
+		{8, []int64{1, 2, 3}, []uint64{1, 2, 3}},
+		{9, []int64{1, 2, 3}, []uint64{1, 2, 3}},
 	}
 	for _, d := range ds {
-		validator.enqueue(d.schemaVersion, d.relatedIDs)
+		validator.enqueue(d.schemaVersion, d.relatedIDs, d.relatedActions)
 	}
-	validator.enqueue(10, []int64{1})
+	validator.enqueue(10, []int64{1}, []uint64{1})
 	ret := []deltaSchemaInfo{
-		{0, []int64{1}},
-		{2, []int64{1}},
-		{3, []int64{2, 2}},
-		{4, []int64{2}},
-		{6, []int64{1, 4}},
-		{9, []int64{1, 2, 3}},
-		{10, []int64{1}},
+		{0, []int64{1}, []uint64{1}},
+		{2, []int64{1}, []uint64{1}},
+		{3, []int64{2, 2}, []uint64{2, 2}},
+		{4, []int64{2}, []uint64{2}},
+		{6, []int64{1, 4}, []uint64{1, 4}},
+		{9, []int64{1, 2, 3}, []uint64{1, 2, 3}},
+		{10, []int64{1}, []uint64{1}},
 	}
 	c.Assert(validator.deltaSchemaInfos, DeepEquals, ret)
 	// The Items' relatedTableIDs have different order.
-	validator.enqueue(11, []int64{1, 2, 3, 4})
-	validator.enqueue(12, []int64{4, 1, 2, 3, 1})
-	validator.enqueue(13, []int64{4, 1, 3, 2, 5})
-	ret[len(ret)-1] = deltaSchemaInfo{13, []int64{4, 1, 3, 2, 5}}
+	validator.enqueue(11, []int64{1, 2, 3, 4}, []uint64{1, 2, 3, 4})
+	validator.enqueue(12, []int64{4, 1, 2, 3, 1}, []uint64{4, 1, 2, 3, 1})
+	validator.enqueue(13, []int64{4, 1, 3, 2, 5}, []uint64{4, 1, 3, 2, 5})
+	ret[len(ret)-1] = deltaSchemaInfo{13, []int64{4, 1, 3, 2, 5}, []uint64{4, 1, 3, 2, 5}}
 	c.Assert(validator.deltaSchemaInfos, DeepEquals, ret)
 	// The length of deltaSchemaInfos is greater then maxCnt.
-	validator.enqueue(14, []int64{1})
-	validator.enqueue(15, []int64{2})
-	validator.enqueue(16, []int64{3})
-	validator.enqueue(17, []int64{4})
-	ret = append(ret, deltaSchemaInfo{14, []int64{1}})
-	ret = append(ret, deltaSchemaInfo{15, []int64{2}})
-	ret = append(ret, deltaSchemaInfo{16, []int64{3}})
-	ret = append(ret, deltaSchemaInfo{17, []int64{4}})
+	validator.enqueue(14, []int64{1}, []uint64{1})
+	validator.enqueue(15, []int64{2}, []uint64{2})
+	validator.enqueue(16, []int64{3}, []uint64{3})
+	validator.enqueue(17, []int64{4}, []uint64{4})
+	ret = append(ret, deltaSchemaInfo{14, []int64{1}, []uint64{1}})
+	ret = append(ret, deltaSchemaInfo{15, []int64{2}, []uint64{2}})
+	ret = append(ret, deltaSchemaInfo{16, []int64{3}, []uint64{3}})
+	ret = append(ret, deltaSchemaInfo{17, []int64{4}, []uint64{4}})
 	c.Assert(validator.deltaSchemaInfos, DeepEquals, ret[1:])
+}
+
+func (*testSuite) TestEnqueueActionType(c *C) {
+	lease := 10 * time.Millisecond
+	originalCnt := variable.GetMaxDeltaSchemaCount()
+	defer variable.SetMaxDeltaSchemaCount(originalCnt)
+
+	validator := NewSchemaValidator(lease).(*schemaValidator)
+	c.Assert(validator.IsStarted(), IsTrue)
+	// maxCnt is 0.
+	variable.SetMaxDeltaSchemaCount(0)
+	validator.enqueue(1, []int64{11}, []uint64{11})
+	c.Assert(validator.deltaSchemaInfos, HasLen, 0)
+
+	// maxCnt is 10.
+	variable.SetMaxDeltaSchemaCount(10)
+	ds := []deltaSchemaInfo{
+		{0, []int64{1}, []uint64{1}},
+		{1, []int64{1}, []uint64{1}},
+		{2, []int64{1}, []uint64{1}},
+		{3, []int64{2, 2}, []uint64{2, 2}},
+		{4, []int64{2}, []uint64{2}},
+		{5, []int64{1, 4}, []uint64{1, 4}},
+		{6, []int64{1, 4}, []uint64{1, 4}},
+		{7, []int64{3, 1, 3}, []uint64{3, 1, 3}},
+		{8, []int64{1, 2, 3}, []uint64{1, 2, 3}},
+		{9, []int64{1, 2, 3}, []uint64{1, 2, 4}},
+	}
+	for _, d := range ds {
+		validator.enqueue(d.schemaVersion, d.relatedIDs, d.relatedActions)
+	}
+	validator.enqueue(10, []int64{1}, []uint64{15})
+	ret := []deltaSchemaInfo{
+		{0, []int64{1}, []uint64{1}},
+		{2, []int64{1}, []uint64{1}},
+		{3, []int64{2, 2}, []uint64{2, 2}},
+		{4, []int64{2}, []uint64{2}},
+		{6, []int64{1, 4}, []uint64{1, 4}},
+		{8, []int64{1, 2, 3}, []uint64{1, 2, 3}},
+		{9, []int64{1, 2, 3}, []uint64{1, 2, 4}},
+		{10, []int64{1}, []uint64{15}},
+	}
+	c.Assert(validator.deltaSchemaInfos, DeepEquals, ret)
+	// Check the flag set by schema diff, note tableID = 3 has been set flag 0x3 in schema version 9, and flag 0x4
+	// in schema version 10, so the resActions for tableID = 3 should be 0x3 & 0x4 = 0x7
+	resTblIDs, resActions, isTablesChanged := validator.isRelatedTablesChanged(5, []int64{1, 3, 4}, true)
+	c.Assert(isTablesChanged, Equals, true)
+	c.Assert(resTblIDs, DeepEquals, []int64{1, 3, 4})
+	c.Assert(resActions, DeepEquals, []uint64{15, 7, 4})
 }

--- a/executor/ddl.go
+++ b/executor/ddl.go
@@ -59,7 +59,7 @@ func (e *DDLExec) toErr(err error) error {
 		logutil.BgLogger().Error("active txn failed", zap.Error(err))
 		return err1
 	}
-	_, _, _, schemaInfoErr := checker.Check(txn.StartTS(), false)
+	_, _, _, _, schemaInfoErr := checker.Check(txn.StartTS(), false)
 	if schemaInfoErr != nil {
 		return errors.Trace(schemaInfoErr)
 	}

--- a/executor/ddl.go
+++ b/executor/ddl.go
@@ -59,7 +59,7 @@ func (e *DDLExec) toErr(err error) error {
 		logutil.BgLogger().Error("active txn failed", zap.Error(err))
 		return err1
 	}
-	schemaInfoErr := checker.Check(txn.StartTS())
+	_, _, _, schemaInfoErr := checker.Check(txn.StartTS(), false)
 	if schemaInfoErr != nil {
 		return errors.Trace(schemaInfoErr)
 	}

--- a/go.mod
+++ b/go.mod
@@ -19,6 +19,7 @@ require (
 	github.com/grpc-ecosystem/go-grpc-middleware v1.0.1-0.20190118093823-f849b5445de4
 	github.com/juju/errors v0.0.0-20181118221551-089d3ea4e4d5
 	github.com/klauspost/cpuid v1.2.1
+	github.com/ngaut/log v0.0.0-20180314031856-b8e36e7ba5ac
 	github.com/ngaut/pools v0.0.0-20180318154953-b7bc8c42aac7
 	github.com/ngaut/sync2 v0.0.0-20141008032647-7a24ed77b2ef
 	github.com/ngaut/unistore v0.0.0-20200604061006-d8e9dc0ad154

--- a/go.sum
+++ b/go.sum
@@ -372,6 +372,8 @@ github.com/mwitkow/go-conntrack v0.0.0-20161129095857-cc309e4a2223/go.mod h1:qRW
 github.com/ncw/directio v1.0.4 h1:CojwI07mCEmRkajgx42Pf8jyCwTs1ji9/Ij9/PJG12k=
 github.com/ncw/directio v1.0.4/go.mod h1:CKGdcN7StAaqjT7Qack3lAXeX4pjnyc46YeqZH1yWVY=
 github.com/nfnt/resize v0.0.0-20160724205520-891127d8d1b5/go.mod h1:jpp1/29i3P1S/RLdc7JQKbRpFeM1dOBd8T9ki5s+AY8=
+github.com/ngaut/log v0.0.0-20180314031856-b8e36e7ba5ac h1:wyheT2lPXRQqYPWY2IVW5BTLrbqCsnhL61zK2R5goLA=
+github.com/ngaut/log v0.0.0-20180314031856-b8e36e7ba5ac/go.mod h1:ueVCjKQllPmX7uEvCYnZD5b8qjidGf1TCH61arVe4SU=
 github.com/ngaut/pools v0.0.0-20180318154953-b7bc8c42aac7 h1:7KAv7KMGTTqSmYZtNdcNTgsos+vFzULLwyElndwn+5c=
 github.com/ngaut/pools v0.0.0-20180318154953-b7bc8c42aac7/go.mod h1:iWMfgwqYW+e8n5lC/jjNEhwcjbRDpl5NT7n2h+4UNcI=
 github.com/ngaut/sync2 v0.0.0-20141008032647-7a24ed77b2ef h1:K0Fn+DoFqNqktdZtdV3bPQ/0cuYh2H4rkg0tytX/07k=

--- a/kv/kv.go
+++ b/kv/kv.go
@@ -56,6 +56,8 @@ const (
 	ReplicaRead
 	// Set task ID
 	TaskID
+	// SchemaAmender is used to amend mutations for pessimistic transactions
+	SchemaAmender
 )
 
 // Priority value for transaction priority.

--- a/session/session.go
+++ b/session/session.go
@@ -1445,6 +1445,7 @@ func (s *session) Txn(active bool) (kv.Transaction, error) {
 		s.sessionVars.TxnCtx.StartTS = s.txn.StartTS()
 		if s.sessionVars.TxnCtx.IsPessimistic {
 			s.txn.SetOption(kv.Pessimistic, true)
+			s.txn.SetOption(kv.SchemaAmender, NewSchemaAmenderForTikvTxn(s))
 		}
 		if !s.sessionVars.IsAutocommit() {
 			s.sessionVars.SetStatusFlag(mysql.ServerStatusInTrans, true)

--- a/store/tikv/region_cache.go
+++ b/store/tikv/region_cache.go
@@ -666,18 +666,18 @@ func (c *RegionCache) GroupKeysByRegion(bo *Backoffer, keys [][]byte, filter fun
 
 type groupedMutations struct {
 	region    RegionVerID
-	mutations committerMutations
+	mutations CommitterMutations
 }
 
 // GroupSortedMutationsByRegion separates keys into groups by their belonging Regions.
-func (c *RegionCache) GroupSortedMutationsByRegion(bo *Backoffer, m committerMutations) ([]groupedMutations, error) {
+func (c *RegionCache) GroupSortedMutationsByRegion(bo *Backoffer, m CommitterMutations) ([]groupedMutations, error) {
 	var (
 		groups  []groupedMutations
 		lastLoc *KeyLocation
 	)
 	lastUpperBound := 0
-	for i := range m.keys {
-		if lastLoc == nil || !lastLoc.Contains(m.keys[i]) {
+	for i := range m.Keys {
+		if lastLoc == nil || !lastLoc.Contains(m.Keys[i]) {
 			if lastLoc != nil {
 				groups = append(groups, groupedMutations{
 					region:    lastLoc.Region,
@@ -686,7 +686,7 @@ func (c *RegionCache) GroupSortedMutationsByRegion(bo *Backoffer, m committerMut
 				lastUpperBound = i
 			}
 			var err error
-			lastLoc, err = c.LocateKey(bo, m.keys[i])
+			lastLoc, err = c.LocateKey(bo, m.Keys[i])
 			if err != nil {
 				return nil, errors.Trace(err)
 			}

--- a/store/tikv/txn.go
+++ b/store/tikv/txn.go
@@ -44,6 +44,12 @@ var (
 	tikvTxnCmdHistogramWithRollback = metrics.TiKVTxnCmdHistogram.WithLabelValues(metrics.LblRollback)
 )
 
+// SchemaAmender is used by pessimistic transactions to amend commit mutations for schema change during 2pc
+type SchemaAmender interface {
+	AmendTxnForSchemaChange(ctx context.Context, startTS uint64, commitTs uint64,
+		dbIDs, tblIDs []int64, actionTypes []uint64, mutations CommitterMutations) (*CommitterMutations, *CommitterMutations, error)
+}
+
 // tikvTxn implements kv.Transaction.
 type tikvTxn struct {
 	snapshot  *tikvSnapshot
@@ -68,6 +74,9 @@ type tikvTxn struct {
 
 	valid bool
 	dirty bool
+
+	// SchemaAmender is used amend pessimistic txn commit mutations for schema change
+	schemaAender SchemaAmender
 }
 
 func newTiKVTxn(store *tikvStore) (*tikvTxn, error) {
@@ -199,6 +208,8 @@ func (txn *tikvTxn) SetOption(opt kv.Option, val interface{}) {
 		txn.snapshot.keyOnly = val.(bool)
 	case kv.SnapshotTS:
 		txn.snapshot.setSnapshotTS(val.(uint64))
+	case kv.SchemaAmender:
+		txn.schemaAender = val.(SchemaAmender)
 	}
 }
 
@@ -278,7 +289,7 @@ func (txn *tikvTxn) Commit(ctx context.Context) error {
 	// latches enabled
 	// for transactions which need to acquire latches
 	start = time.Now()
-	lock := txn.store.txnLatches.Lock(committer.startTS, committer.mutations.keys)
+	lock := txn.store.txnLatches.Lock(committer.startTS, committer.mutations.Keys)
 	commitDetail := committer.getDetail()
 	commitDetail.LocalLatchTime = time.Since(start)
 	if commitDetail.LocalLatchTime > 0 {
@@ -323,12 +334,12 @@ func (txn *tikvTxn) rollbackPessimisticLocks() error {
 	if len(txn.lockKeys) == 0 {
 		return nil
 	}
-	return txn.committer.pessimisticRollbackMutations(NewBackoffer(context.Background(), cleanupMaxBackoff), committerMutations{keys: txn.lockKeys})
+	return txn.committer.pessimisticRollbackMutations(NewBackoffer(context.Background(), cleanupMaxBackoff), CommitterMutations{Keys: txn.lockKeys})
 }
 
 // lockWaitTime in ms, except that kv.LockAlwaysWait(0) means always wait lock, kv.LockNowait(-1) means nowait lock
 func (txn *tikvTxn) LockKeys(ctx context.Context, lockCtx *kv.LockCtx, keysInput ...kv.Key) error {
-	// Exclude keys that are already locked.
+	// Exclude Keys that are already locked.
 	var err error
 	keys := make([][]byte, 0, len(keysInput))
 	defer func() {
@@ -350,7 +361,7 @@ func (txn *tikvTxn) LockKeys(ctx context.Context, lockCtx *kv.LockCtx, keysInput
 		if _, ok := txn.lockedMap[string(key)]; !ok {
 			keys = append(keys, key)
 		} else if lockCtx.ReturnValues {
-			// An already locked key can not return values, we add an entry to let the caller get the value
+			// An already locked key can not return Values, we add an entry to let the caller get the value
 			// in other ways.
 			lockCtx.Values[string(key)] = kv.ReturnedValue{AlreadyLocked: true}
 		}
@@ -382,10 +393,10 @@ func (txn *tikvTxn) LockKeys(ctx context.Context, lockCtx *kv.LockCtx, keysInput
 
 		bo := NewBackoffer(ctx, pessimisticLockMaxBackoff).WithVars(txn.vars)
 		txn.committer.forUpdateTS = lockCtx.ForUpdateTS
-		// If the number of keys greater than 1, it can be on different region,
+		// If the number of Keys greater than 1, it can be on different region,
 		// concurrently execute on multiple regions may lead to deadlock.
 		txn.committer.isFirstLock = len(txn.lockKeys) == 0 && len(keys) == 1
-		err = txn.committer.pessimisticLockMutations(bo, lockCtx, committerMutations{keys: keys})
+		err = txn.committer.pessimisticLockMutations(bo, lockCtx, CommitterMutations{Keys: keys})
 		if lockCtx.Killed != nil {
 			// If the kill signal is received during waiting for pessimisticLock,
 			// pessimisticLockKeys would handle the error but it doesn't reset the flag.
@@ -431,7 +442,7 @@ func (txn *tikvTxn) LockKeys(ctx context.Context, lockCtx *kv.LockCtx, keysInput
 	return nil
 }
 
-// deduplicateKeys deduplicate the keys, it use sort instead of map to avoid memory allocation.
+// deduplicateKeys deduplicate the Keys, it use sort instead of map to avoid memory allocation.
 func deduplicateKeys(keys [][]byte) [][]byte {
 	sort.Slice(keys, func(i, j int) bool {
 		return bytes.Compare(keys[i], keys[j]) < 0
@@ -460,7 +471,7 @@ func (txn *tikvTxn) asyncPessimisticRollback(ctx context.Context, keys [][]byte)
 		failpoint.Inject("AsyncRollBackSleep", func() {
 			time.Sleep(100 * time.Millisecond)
 		})
-		err := committer.pessimisticRollbackMutations(NewBackoffer(ctx, pessimisticRollbackMaxBackoff).WithVars(txn.vars), committerMutations{keys: keys})
+		err := committer.pessimisticRollbackMutations(NewBackoffer(ctx, pessimisticRollbackMaxBackoff).WithVars(txn.vars), CommitterMutations{Keys: keys})
 		if err != nil {
 			logutil.Logger(ctx).Warn("[kv] pessimisticRollback failed.", zap.Error(err))
 		}

--- a/tablecodec/tablecodec.go
+++ b/tablecodec/tablecodec.go
@@ -1009,7 +1009,7 @@ func GenIndexValue(sc *stmtctx.StatementContext, tblInfo *model.TableInfo, idxIn
 		idxValCap := 1 + 1 + 2 + h.Len() + len(rowRestoredValue)
 		idxVal = make([]byte, 1, idxValCap)
 		if !h.IsInt() && distinct {
-			idxVal = encodeCommonHandle(idxVal, h)
+			idxVal = EncodeCommonHandle(idxVal, h)
 		}
 		idxVal = append(idxVal, rowRestoredValue...)
 		tailLen := 0
@@ -1093,10 +1093,11 @@ func EncodeHandleInUniqueIndexValue(h kv.Handle, isUntouched bool) []byte {
 	if isUntouched {
 		untouchedFlag = 1
 	}
-	return encodeCommonHandle([]byte{untouchedFlag}, h)
+	return EncodeCommonHandle([]byte{untouchedFlag}, h)
 }
 
-func encodeCommonHandle(idxVal []byte, h kv.Handle) []byte {
+// EncodeCommonHandle encodes handle key
+func EncodeCommonHandle(idxVal []byte, h kv.Handle) []byte {
 	idxVal = append(idxVal, CommonHandleFlag)
 	hLen := uint16(len(h.Encoded()))
 	idxVal = append(idxVal, byte(hLen>>8), byte(hLen))


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/tidb/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->



### What is changed and how it works?

DDL related changes:
1. Record schema change action types for each schema diff, we can know whether a table has unsupported changes without comparing the whole `model.TableInfo` object.

2PC related changes:
1. Add `getAll` field for schema check, if `getAll` flag is true, try to get all schema change action types for each related table, and return if it's amendable for these schema change types.
2. If changes are amendable, try to diff two `model.TableInfo` using two schema meta with `startTS` and `commitTS`. Check every index in new and old table, then generate index change related amend operations.
3. Try to amend these operations, using `Txn.BatchGet` to fetch oldRows,  generate index keys and values based on operation type, then generate new mutations which need prewrite, and old mutations which need rollback
4. Amend mutations in `twoPhaseCommiter` and then try to commit


### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test


Code changes



Side effects



Related changes

